### PR TITLE
fix: address core review issues

### DIFF
--- a/packages/core/src/__tests__/auth.test.ts
+++ b/packages/core/src/__tests__/auth.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { buildClientAuthHeaders } from "../auth.js";
+import type { OidcConfig } from "../types.js";
+
+describe("buildClientAuthHeaders", () => {
+  // RFC 6749 §2.3.1: HTTP Basic authentication for confidential clients
+  it("RFC 6749 §2.3.1: returns Basic auth header for confidential client", () => {
+    const config: OidcConfig = {
+      issuer: "https://auth.example.com",
+      clientId: "my-app",
+      clientSecret: "my-secret",
+    };
+
+    const headers = buildClientAuthHeaders(config);
+    const expected = btoa("my-app:my-secret");
+
+    expect(headers["Authorization"]).toBe(`Basic ${expected}`);
+  });
+
+  it("returns empty object for public client", () => {
+    const config: OidcConfig = {
+      issuer: "https://auth.example.com",
+      clientId: "my-app",
+    };
+
+    const headers = buildClientAuthHeaders(config);
+
+    expect(headers).toEqual({});
+  });
+});

--- a/packages/core/src/__tests__/crypto.test.ts
+++ b/packages/core/src/__tests__/crypto.test.ts
@@ -8,6 +8,7 @@ import {
   base64UrlEncode,
   base64UrlDecode,
 } from "../crypto.js";
+import { OidcError } from "../errors.js";
 
 describe("base64UrlEncode / base64UrlDecode", () => {
   it("roundtrip preserves data", () => {
@@ -23,6 +24,16 @@ describe("base64UrlEncode / base64UrlDecode", () => {
     expect(encoded).not.toContain("+");
     expect(encoded).not.toContain("/");
     expect(encoded).not.toContain("=");
+  });
+
+  it("throws OidcError INVALID_JWT on invalid base64 input", () => {
+    try {
+      base64UrlDecode("!!!invalid-base64!!!");
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("INVALID_JWT");
+    }
   });
 });
 
@@ -42,6 +53,12 @@ describe("generateRandom", () => {
     const a = generateRandom();
     const b = generateRandom();
     expect(a).not.toBe(b);
+  });
+
+  it("produces uniform distribution without modulo bias", () => {
+    const result = generateRandom(1000);
+    expect(result.length).toBe(1000);
+    expect(result).toMatch(/^[A-Za-z0-9\-._~]+$/);
   });
 });
 

--- a/packages/core/src/__tests__/discovery.test.ts
+++ b/packages/core/src/__tests__/discovery.test.ts
@@ -72,4 +72,48 @@ describe("parseDiscoveryResponse", () => {
     const result = parseDiscoveryResponse(VALID_DISCOVERY, "https://auth.example.com/");
     expect(result.issuer).toBe("https://auth.example.com");
   });
+
+  it("throws DISCOVERY_INVALID when string fields have wrong type", () => {
+    const badIssuer = { ...VALID_DISCOVERY, issuer: 123 };
+    try {
+      parseDiscoveryResponse(badIssuer, "https://auth.example.com");
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("DISCOVERY_INVALID");
+      expect((e as OidcError).message).toContain("issuer");
+    }
+
+    const badEndpoint = { ...VALID_DISCOVERY, token_endpoint: true };
+    try {
+      parseDiscoveryResponse(badEndpoint, "https://auth.example.com");
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("DISCOVERY_INVALID");
+      expect((e as OidcError).message).toContain("token_endpoint");
+    }
+  });
+
+  it("throws DISCOVERY_INVALID when array fields have wrong type", () => {
+    const badArray = { ...VALID_DISCOVERY, response_types_supported: "code" };
+    try {
+      parseDiscoveryResponse(badArray, "https://auth.example.com");
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("DISCOVERY_INVALID");
+      expect((e as OidcError).message).toContain("response_types_supported");
+    }
+
+    const badSubjects = { ...VALID_DISCOVERY, subject_types_supported: null };
+    try {
+      parseDiscoveryResponse(badSubjects, "https://auth.example.com");
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("DISCOVERY_INVALID");
+      expect((e as OidcError).message).toContain("subject_types_supported");
+    }
+  });
 });

--- a/packages/core/src/__tests__/introspect.test.ts
+++ b/packages/core/src/__tests__/introspect.test.ts
@@ -15,6 +15,11 @@ const DISCOVERY: OidcDiscovery = {
   id_token_signing_alg_values_supported: ["RS256"],
 };
 
+const DISCOVERY_NO_INTROSPECT: OidcDiscovery = {
+  ...DISCOVERY,
+  introspection_endpoint: undefined,
+};
+
 const CONFIG: OidcConfig = {
   issuer: "https://auth.example.com",
   clientId: "my-api",
@@ -25,20 +30,22 @@ describe("buildIntrospectRequest", () => {
   // RFC 7662 §2.1: Introspection Request
   it("RFC 7662 §2.1: includes token parameter", () => {
     const req = buildIntrospectRequest(DISCOVERY, CONFIG, "at_xyz");
-    const params = new URLSearchParams(req.body);
+    expect(req).not.toBeNull();
+    const params = new URLSearchParams(req!.body);
 
     expect(params.get("token")).toBe("at_xyz");
-    expect(req.method).toBe("POST");
-    expect(req.url).toBe("https://auth.example.com/introspect");
+    expect(req!.method).toBe("POST");
+    expect(req!.url).toBe("https://auth.example.com/introspect");
   });
 
   // RFC 7662 §2.1: protected resource MUST authenticate
   it("RFC 7662 §2.1: adds Basic auth header", () => {
     const req = buildIntrospectRequest(DISCOVERY, CONFIG, "at_xyz");
+    expect(req).not.toBeNull();
     const expected = btoa("my-api:api-secret");
 
-    expect(req.headers["Authorization"]).toBe(`Basic ${expected}`);
-    expect(req.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
+    expect(req!.headers["Authorization"]).toBe(`Basic ${expected}`);
+    expect(req!.headers["Content-Type"]).toBe("application/x-www-form-urlencoded");
   });
 
   it("throws MISSING_CLIENT_SECRET without clientSecret", () => {
@@ -54,6 +61,11 @@ describe("buildIntrospectRequest", () => {
       expect(e).toBeInstanceOf(OidcError);
       expect((e as OidcError).code).toBe("MISSING_CLIENT_SECRET");
     }
+  });
+
+  it("returns null when no introspection_endpoint", () => {
+    const req = buildIntrospectRequest(DISCOVERY_NO_INTROSPECT, CONFIG, "at_xyz");
+    expect(req).toBeNull();
   });
 });
 
@@ -83,5 +95,31 @@ describe("parseIntrospectResponse", () => {
     const result = parseIntrospectResponse({ active: false });
 
     expect(result.active).toBe(false);
+  });
+
+  it("throws TOKEN_EXCHANGE_ERROR on non-object input", () => {
+    expect(() => parseIntrospectResponse(null)).toThrow(OidcError);
+    expect(() => parseIntrospectResponse("string")).toThrow(OidcError);
+    expect(() => parseIntrospectResponse(42)).toThrow(OidcError);
+  });
+
+  it("throws TOKEN_EXCHANGE_ERROR when active field is missing", () => {
+    try {
+      parseIntrospectResponse({ scope: "openid" });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+    }
+  });
+
+  it("throws TOKEN_EXCHANGE_ERROR when active field is not boolean", () => {
+    try {
+      parseIntrospectResponse({ active: "true" });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+    }
   });
 });

--- a/packages/core/src/__tests__/userinfo.test.ts
+++ b/packages/core/src/__tests__/userinfo.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildUserinfoRequest, parseUserinfoResponse } from "../userinfo.js";
+import { OidcError } from "../errors.js";
 import type { OidcDiscovery } from "../types.js";
 
 const DISCOVERY: OidcDiscovery = {
@@ -27,6 +28,12 @@ describe("buildUserinfoRequest", () => {
 
     expect(req.method).toBe("GET");
     expect(req.url).toBe("https://auth.example.com/userinfo");
+  });
+
+  it("does not include a body on GET request", () => {
+    const req = buildUserinfoRequest(DISCOVERY, "at_123");
+
+    expect(req.body).toBeUndefined();
   });
 });
 
@@ -59,5 +66,32 @@ describe("parseUserinfoResponse", () => {
 
     expect(user.custom_claim).toBe("custom_value");
     expect(user.groups).toEqual(["admin", "users"]);
+  });
+
+  it("throws TOKEN_EXCHANGE_ERROR on non-object input", () => {
+    expect(() => parseUserinfoResponse(null)).toThrow(OidcError);
+    expect(() => parseUserinfoResponse("string")).toThrow(OidcError);
+    expect(() => parseUserinfoResponse(42)).toThrow(OidcError);
+  });
+
+  // OIDC Core §5.3.2: sub claim is REQUIRED
+  it("OIDC Core §5.3.2: throws TOKEN_EXCHANGE_ERROR when sub claim is missing", () => {
+    try {
+      parseUserinfoResponse({ email: "user@example.com" });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+    }
+  });
+
+  it("throws TOKEN_EXCHANGE_ERROR when sub claim is not a string", () => {
+    try {
+      parseUserinfoResponse({ sub: 123, email: "user@example.com" });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+    }
   });
 });

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,0 +1,8 @@
+import type { OidcConfig } from "./types.js";
+
+// RFC 6749 §2.3.1: HTTP Basic authentication with client_id:client_secret
+export function buildClientAuthHeaders(config: OidcConfig): Record<string, string> {
+  if (!config.clientSecret) return {};
+  const credentials = btoa(`${config.clientId}:${config.clientSecret}`);
+  return { Authorization: `Basic ${credentials}` };
+}

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -1,3 +1,5 @@
+import { OidcError } from "./errors.js";
+
 // RFC 7636 §4.1: unreserved characters for code_verifier
 const UNRESERVED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
 
@@ -10,22 +12,33 @@ export function base64UrlEncode(bytes: Uint8Array): string {
 }
 
 export function base64UrlDecode(str: string): Uint8Array {
-  const padded = str.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (str.length % 4)) % 4);
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
+  try {
+    const padded = str.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (str.length % 4)) % 4);
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } catch {
+    throw new OidcError("INVALID_JWT", "Invalid base64url input");
   }
-  return bytes;
 }
 
 // RFC 7636 §4.1: code_verifier has minimum 256 bits of entropy
+// Rejection sampling avoids modulo bias (256 % 66 != 0)
 export function generateRandom(length: number = 32): string {
-  const bytes = new Uint8Array(length);
-  crypto.getRandomValues(bytes);
+  const alphabetSize = UNRESERVED.length;
+  const limit = 256 - (256 % alphabetSize);
   let result = "";
-  for (const byte of bytes) {
-    result += UNRESERVED[byte % UNRESERVED.length];
+  while (result.length < length) {
+    const bytes = new Uint8Array(length - result.length);
+    crypto.getRandomValues(bytes);
+    for (const byte of bytes) {
+      if (byte < limit && result.length < length) {
+        result += UNRESERVED[byte % alphabetSize];
+      }
+    }
   }
   return result;
 }

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -6,11 +6,14 @@ export function buildDiscoveryUrl(issuer: string): string {
   return `${issuer.replace(/\/+$/, "")}/.well-known/openid-configuration`;
 }
 
-const REQUIRED_FIELDS: (keyof OidcDiscovery)[] = [
+const REQUIRED_STRING_FIELDS: (keyof OidcDiscovery)[] = [
   "issuer",
   "authorization_endpoint",
   "token_endpoint",
   "jwks_uri",
+];
+
+const REQUIRED_ARRAY_FIELDS: (keyof OidcDiscovery)[] = [
   "response_types_supported",
   "subject_types_supported",
   "id_token_signing_alg_values_supported",
@@ -24,9 +27,15 @@ export function parseDiscoveryResponse(data: unknown, expectedIssuer: string): O
 
   const doc = data as Record<string, unknown>;
 
-  for (const field of REQUIRED_FIELDS) {
-    if (doc[field] === undefined || doc[field] === null) {
-      throw new OidcError("DISCOVERY_INVALID", `Missing required field: ${field}`);
+  for (const field of REQUIRED_STRING_FIELDS) {
+    if (typeof doc[field] !== "string") {
+      throw new OidcError("DISCOVERY_INVALID", `Missing or invalid required field: ${field}`);
+    }
+  }
+
+  for (const field of REQUIRED_ARRAY_FIELDS) {
+    if (!Array.isArray(doc[field])) {
+      throw new OidcError("DISCOVERY_INVALID", `Missing or invalid required field: ${field}`);
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export { buildRevocationRequest } from "./revocation.js";
 export { buildLogoutUrl } from "./logout.js";
 export { decodeJwtPayload, parseIdTokenClaims } from "./jwt.js";
 export { computeExpiresAt, isTokenExpired, timeUntilExpiry } from "./token-utils.js";
+export { buildClientAuthHeaders } from "./auth.js";
 
 export type {
   OidcConfig,

--- a/packages/core/src/introspect.ts
+++ b/packages/core/src/introspect.ts
@@ -1,28 +1,29 @@
 import type { OidcConfig, OidcDiscovery, HttpRequest, IntrospectionResponse } from "./types.js";
 import { OidcError } from "./errors.js";
+import { buildClientAuthHeaders } from "./auth.js";
 
 // RFC 7662 §2.1: Introspection Request
 export function buildIntrospectRequest(
   discovery: OidcDiscovery,
   config: OidcConfig,
   token: string,
-): HttpRequest {
+): HttpRequest | null {
+  if (!discovery.introspection_endpoint) {
+    return null;
+  }
+
   if (!config.clientSecret) {
     throw new OidcError("MISSING_CLIENT_SECRET", "clientSecret is required for token introspection");
   }
 
-  // RFC 7662 §2.1: the protected resource authenticates with the authorization server
-  // RFC 6749 §2.3.1: HTTP Basic authentication
-  const credentials = btoa(`${config.clientId}:${config.clientSecret}`);
-
   const body = new URLSearchParams({ token });
 
   return {
-    url: discovery.introspection_endpoint!,
+    url: discovery.introspection_endpoint,
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
-      Authorization: `Basic ${credentials}`,
+      ...buildClientAuthHeaders(config),
     },
     body: body.toString(),
   };
@@ -30,5 +31,15 @@ export function buildIntrospectRequest(
 
 // RFC 7662 §2.2: Introspection Response
 export function parseIntrospectResponse(data: unknown): IntrospectionResponse {
+  if (!data || typeof data !== "object") {
+    throw new OidcError("TOKEN_EXCHANGE_ERROR", "Introspection response must be a JSON object");
+  }
+
+  const response = data as Record<string, unknown>;
+
+  if (typeof response.active !== "boolean") {
+    throw new OidcError("TOKEN_EXCHANGE_ERROR", "Missing or invalid 'active' field in introspection response");
+  }
+
   return data as IntrospectionResponse;
 }

--- a/packages/core/src/revocation.ts
+++ b/packages/core/src/revocation.ts
@@ -1,4 +1,5 @@
 import type { OidcConfig, OidcDiscovery, HttpRequest } from "./types.js";
+import { buildClientAuthHeaders } from "./auth.js";
 
 // RFC 7009 §2.1: Token Revocation Request
 export function buildRevocationRequest(
@@ -18,20 +19,13 @@ export function buildRevocationRequest(
     body.set("token_type_hint", tokenTypeHint);
   }
 
-  const headers: Record<string, string> = {
-    "Content-Type": "application/x-www-form-urlencoded",
-  };
-
-  // RFC 6749 §2.3.1: confidential clients authenticate via Basic auth
-  if (config.clientSecret) {
-    const credentials = btoa(`${config.clientId}:${config.clientSecret}`);
-    headers["Authorization"] = `Basic ${credentials}`;
-  }
-
   return {
     url: discovery.revocation_endpoint,
     method: "POST",
-    headers,
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...buildClientAuthHeaders(config),
+    },
     body: body.toString(),
   };
 }

--- a/packages/core/src/token.ts
+++ b/packages/core/src/token.ts
@@ -1,13 +1,7 @@
 import type { OidcConfig, OidcDiscovery, HttpRequest, TokenSet } from "./types.js";
 import { OidcError } from "./errors.js";
 import { decodeJwtPayload } from "./jwt.js";
-
-function buildClientAuth(config: OidcConfig): Record<string, string> {
-  if (!config.clientSecret) return {};
-  // RFC 6749 §2.3.1: HTTP Basic authentication with client_id:client_secret
-  const credentials = btoa(`${config.clientId}:${config.clientSecret}`);
-  return { Authorization: `Basic ${credentials}` };
-}
+import { buildClientAuthHeaders } from "./auth.js";
 
 // RFC 6749 §4.1.3: Access Token Request
 // RFC 7636 §4.5: code_verifier MUST be sent when code_challenge was used
@@ -34,7 +28,7 @@ export function buildTokenRequest(
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
-      ...buildClientAuth(config),
+      ...buildClientAuthHeaders(config),
     },
     body: body.toString(),
   };
@@ -57,7 +51,7 @@ export function buildRefreshRequest(
     method: "POST",
     headers: {
       "Content-Type": "application/x-www-form-urlencoded",
-      ...buildClientAuth(config),
+      ...buildClientAuthHeaders(config),
     },
     body: body.toString(),
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -59,7 +59,7 @@ export interface HttpRequest {
   url: string;
   method: string;
   headers: Record<string, string>;
-  body: string;
+  body?: string;
 }
 
 export interface IntrospectionResponse {

--- a/packages/core/src/userinfo.ts
+++ b/packages/core/src/userinfo.ts
@@ -1,4 +1,5 @@
 import type { OidcDiscovery, HttpRequest, OidcUser } from "./types.js";
+import { OidcError } from "./errors.js";
 
 // OIDC Core §5.3.1: UserInfo Request
 // RFC 6750 §2.1: Bearer token in Authorization header
@@ -9,11 +10,21 @@ export function buildUserinfoRequest(discovery: OidcDiscovery, accessToken: stri
     headers: {
       Authorization: `Bearer ${accessToken}`,
     },
-    body: "",
   };
 }
 
-// OIDC Core §5.3.2: UserInfo Response — standard claims
+// OIDC Core §5.3.2: UserInfo Response
 export function parseUserinfoResponse(data: unknown): OidcUser {
+  if (!data || typeof data !== "object") {
+    throw new OidcError("TOKEN_EXCHANGE_ERROR", "UserInfo response must be a JSON object");
+  }
+
+  const response = data as Record<string, unknown>;
+
+  // OIDC Core §5.3.2: sub claim is REQUIRED
+  if (typeof response.sub !== "string") {
+    throw new OidcError("TOKEN_EXCHANGE_ERROR", "Missing or invalid 'sub' claim in UserInfo response");
+  }
+
   return data as OidcUser;
 }


### PR DESCRIPTION
## Summary

- Fix modulo bias in `generateRandom` using rejection sampling (256 is not divisible by 66)
- Validate field types in `parseDiscoveryResponse`: string fields checked with `typeof`, array fields with `Array.isArray`
- Wrap `base64UrlDecode` `atob` call in try/catch, throwing `OidcError("INVALID_JWT")` instead of `DOMException`
- Add response validation in `parseUserinfoResponse` (sub claim required) and `parseIntrospectResponse` (active boolean required)
- `buildIntrospectRequest` returns `HttpRequest | null` when no introspection endpoint
- Extract shared `buildClientAuthHeaders` to `auth.ts`, deduplicate across token, introspect, and revocation
- Make `HttpRequest.body` optional for GET requests (userinfo)
- Add negative test cases for all new validation paths (95 tests total)

## Test plan
- [x] All 95 tests pass (`pnpm --filter oidc-js-core test`)
- [x] Type check passes (`pnpm --filter oidc-js-core lint`)
- [x] Build succeeds (`pnpm --filter oidc-js-core build`)
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)