### PR TITLE
feat: E2E harness, RequireAuth exp check, onLogin/onError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,25 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(pnpm --filter e2e-tests exec playwright --version | head -1)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter e2e-tests exec playwright install --with-deps chromium
+
+      - name: Install Playwright deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter e2e-tests exec playwright install-deps chromium
+
+      - name: E2E tests
+        run: pnpm --filter e2e-tests test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm -r lint
 
       - name: Test
-        run: pnpm --filter '!e2e-tests' test
+        run: pnpm -r --filter '!e2e-tests' --filter '!e2e-react-app' test
 
       - name: Get Playwright version
         id: playwright-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm -r lint
 
       - name: Test
-        run: pnpm -r --filter '!e2e-tests' --filter '!e2e-react-app' test
+        run: pnpm -r --filter '!e2e-tests' --filter '!e2e-react-app' --filter '!oidc-js-monorepo' test
 
       - name: Get Playwright version
         id: playwright-version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm -r lint
 
       - name: Test
-        run: pnpm test
+        run: pnpm --filter '!e2e-tests' test
 
       - name: Get Playwright version
         id: playwright-version

--- a/decisions.md
+++ b/decisions.md
@@ -131,3 +131,96 @@ Architectural and design decisions for the oidc-js project. Each entry captures 
 **Decision**: Tokens (access, id, refresh) stored in React state only. PKCE verifier, state, and nonce stored in sessionStorage during the redirect, cleared immediately after callback processing.
 
 **Rationale**: Memory-only tokens are the most secure option for SPAs (no XSS exfiltration from storage). PKCE state must survive a full page navigation (redirect to IdP and back), so sessionStorage is the only viable option. It's cleared as soon as the callback is processed.
+
+### 012 - RequireAuth checks access token `exp` claim, not just `isAuthenticated` boolean (2026-04-30)
+
+**Context**: RequireAuth initially only checked the `isAuthenticated` boolean from context. This meant an expired access token was invisible to the component — a user who left a tab open for hours would see stale "authenticated" UI until something explicitly set `isAuthenticated` to false.
+
+**Alternatives considered**:
+1. Check only `isAuthenticated` boolean (original behavior)
+2. Decode JWT and check `exp` on every render
+3. Decode `exp` once when tokens arrive, store `expiresAt` in state, compare on render
+
+**Decision**: Option 3. AuthProvider decodes `exp` from the access token once during token exchange and stores `tokens.expiresAt` (milliseconds since epoch). RequireAuth compares `expiresAt` to `Date.now()` — if expired, it triggers auto-refresh (if enabled) before showing children.
+
+**Rationale**: Option 2 decodes a JWT on every render, which is wasteful. `expiresAt` is derived once and stored alongside the tokens. RequireAuth uses `effectivelyAuthenticated = isAuthenticated && (expiresAt === null || expiresAt > Date.now())`, making the check a simple number comparison.
+
+### 013 - `tokens.expiresAt` naming over `tokens.accessExpiresAt` (2026-04-30)
+
+**Context**: The `AuthTokens` type groups `access`, `id`, `refresh`, and the expiration timestamp. The timestamp is derived from the access token's `exp` claim.
+
+**Alternatives considered**:
+1. `accessExpiresAt` — explicit about which token
+2. `expiresAt` — shorter, relies on context
+
+**Decision**: `expiresAt`. Inside the `tokens` object, the fields `access`, `id`, `refresh` already establish that this is token-related. `accessExpiresAt` is redundant — like `user.userName`. If we ever need refresh token expiration, it can be `refreshExpiresAt` while `expiresAt` stays as the primary (access token) expiration.
+
+### 014 - `onLogin(returnTo)` callback for post-login navigation (2026-04-30)
+
+**Context**: After OAuth callback, the library needs to navigate the user back to the page they were on before login. With memory-only tokens, the full page reload during the redirect wipes React state, so the library can't rely on in-memory state for the return URL.
+
+**Alternatives considered**:
+1. `onLogin({ returnTo, user })` — structured object with user info for routing decisions (Auth0 pattern)
+2. `onLogin(returnTo: string)` — just the URL string
+3. `onRedirectCallback(appState)` — extensible app state object (Auth0's `appState` pattern)
+4. No callback, always `replaceState` (oidc-client-ts default)
+
+**Decision**: `onLogin(returnTo: string)` prop on AuthProvider. `returnTo` is automatically captured from `window.location.href` when `actions.login()` is called, saved in sessionStorage alongside PKCE state, and passed to the callback after token exchange. Default when no `onLogin` provided: `window.history.replaceState({}, "", returnTo)`.
+
+**Rationale**: Passing `user` in the callback was considered, but `onLogin` runs inside AuthProvider before context propagates to children — so `useAuth()` isn't available there anyway. User-dependent routing decisions belong in child components via `useAuth()`, not in the provider callback. A plain string keeps the API simple and router-agnostic. Override with `actions.login({ returnTo: "/custom" })`.
+
+### 015 - E2E test harness with Autentico as real OIDC IdP (2026-04-30)
+
+**Context**: Needed E2E tests that verify the full OIDC flow (redirect, login, callback, token exchange, refresh, logout) against a real identity provider, not mocks.
+
+**Alternatives considered**:
+1. Mock the IdP endpoints in the test
+2. Use a third-party test IdP service
+3. Use Autentico (our own IdP) as a real test server
+
+**Decision**: Option 3. Playwright global-setup downloads the Autentico release binary, initializes a fresh instance, creates test users and clients via the admin API, and tears it down after tests. The harness lives in `tests/e2e/` with the backend setup shared across framework adapters.
+
+**Rationale**: We control both sides of the OIDC flow. Mocking the IdP defeats the purpose of E2E tests. Using our own IdP means we can configure it exactly as needed (CORS, token expiration, client settings) via the admin API. The test app for each framework adapter is separate, but the Autentico setup is identical.
+
+### 016 - Short TTL for RequireAuth auto-refresh E2E test (2026-04-30)
+
+**Context**: Needed to test that RequireAuth automatically refreshes an expired access token when navigating between protected pages. The challenge is triggering token expiration deterministically without flaky timing.
+
+**Alternatives considered**:
+1. `page.evaluate()` to corrupt the access token in React state — deterministic but couples test to internals
+2. Expose a test hook on AuthProvider — compromises library API security
+3. Short access token TTL (1s) via per-client override, wait 5s — simple, wide margin
+4. Revoke access token server-side — client doesn't know it's revoked
+
+**Decision**: Option 3. Set `access_token_expiration: "1s"` on the test client via Autentico's admin API before the test, wait 5 seconds for expiration, navigate to a second RequireAuth page. Reset after the test.
+
+**Rationale**: 5x margin (5s wait vs 1s TTL) is reliable even on slow CI. No changes to the library API. Per-client override means other tests aren't affected. The test verifies the real flow: token expires → RequireAuth detects `expiresAt < now` → calls refresh → gets new tokens → renders protected content.
+
+### 017 - Token expiration buffer on AuthProvider (2026-04-30)
+
+**Context**: RequireAuth compares `tokens.expiresAt` to `Date.now()` to detect expired tokens. An exact comparison creates a race: a request can go out with a token that expires mid-flight.
+
+**Decision**: Add `tokenExpirationBuffer` prop on AuthProvider (default 30 seconds). RequireAuth treats the token as expired `buffer` seconds before actual expiration: `expiresAt - buffer > Date.now()`.
+
+**Rationale**: 30s default is conservative enough to cover most request round-trips without triggering unnecessary refreshes. Configurable for apps with different needs (long-running uploads, real-time connections).
+
+### 018 - `onError` callback on AuthProvider (2026-04-30)
+
+**Context**: When token exchange or discovery fails during the redirect callback, the library sets `error` state. Apps may want to handle errors externally (logging, analytics, error reporting) without watching state changes.
+
+**Decision**: Add `onError(error: Error)` prop on AuthProvider. Called when discovery, token exchange, or refresh fails. Does not replace the `error` state — both fire.
+
+**Rationale**: Mirrors the `onLogin` pattern. Auth0 passes errors to its callback too. Separating error handling from rendering keeps components focused on UI while infrastructure concerns (logging, reporting) live at the provider level.
+
+### 019 - Callback detection is URL-agnostic, no dedicated callback route needed (2026-04-30)
+
+**Context**: After the IdP redirects back with `code` and `state` params, the library needs to detect and process the callback. Some libraries require a dedicated `/callback` route component.
+
+**Alternatives considered**:
+1. Require a `<CallbackHandler>` component at a specific route
+2. Match current URL against `redirectUri` before processing
+3. Detect `code` + `state` params anywhere, validate against saved session state
+
+**Decision**: Option 3. AuthProvider checks for `code` and `state` query params on mount regardless of the current path. It validates `state` against the value saved in sessionStorage during login — only a matching state triggers callback processing.
+
+**Rationale**: No extra route setup, no callback component, works with any router or no router. The `state` validation prevents false positives — random query params won't trigger processing. The `redirectUri` in config is purely for the IdP ("where to send the browser"), not for the library. This is the same approach Auth0 uses.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -45,6 +45,7 @@ export interface AuthState {
   state: string;
   nonce: string;
   redirectUri: string;
+  returnTo?: string;
 }
 
 export interface OidcUser {

--- a/packages/react/src/auth-required.tsx
+++ b/packages/react/src/auth-required.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, useMemo, type ReactNode } from "react";
 import { useAuth } from "./context.js";
 
 interface RequireAuthProps {
@@ -12,18 +12,23 @@ export function RequireAuth({
   fallback = null,
   autoRefresh = true,
 }: RequireAuthProps) {
-  const { isAuthenticated, isLoading, actions } = useAuth();
+  const { isAuthenticated, isLoading, tokens, actions } = useAuth();
   const refreshAttempted = useRef(false);
   const [refreshing, setRefreshing] = useState(false);
 
-  useEffect(() => {
-    if (isAuthenticated) {
-      refreshAttempted.current = false;
-    }
-  }, [isAuthenticated]);
+  const effectivelyAuthenticated = useMemo(
+    () => isAuthenticated && (tokens.expiresAt === null || tokens.expiresAt > Date.now()),
+    [isAuthenticated, tokens.expiresAt],
+  );
 
   useEffect(() => {
-    if (isLoading || isAuthenticated || refreshing) return;
+    if (effectivelyAuthenticated) {
+      refreshAttempted.current = false;
+    }
+  }, [effectivelyAuthenticated]);
+
+  useEffect(() => {
+    if (isLoading || effectivelyAuthenticated || refreshing) return;
 
     if (autoRefresh && !refreshAttempted.current) {
       refreshAttempted.current = true;
@@ -36,9 +41,9 @@ export function RequireAuth({
     }
 
     actions.login();
-  }, [isLoading, isAuthenticated, refreshing, autoRefresh, actions]);
+  }, [isLoading, effectivelyAuthenticated, refreshing, autoRefresh, actions]);
 
-  if (isLoading || refreshing || !isAuthenticated) {
+  if (isLoading || refreshing || !effectivelyAuthenticated) {
     return fallback;
   }
 

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -47,7 +47,7 @@ function extractExpiresAt(accessToken: string): number | null {
   try {
     const payload = decodeJwtPayload(accessToken);
     if (typeof payload.exp === "number") return payload.exp * 1000;
-  } catch {}
+  } catch { /* malformed JWT */ }
   return null;
 }
 

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -29,21 +29,33 @@ import {
 } from "oidc-js-core";
 import { executeFetch } from "./fetch.js";
 import { saveAuthState, loadAuthState, clearAuthState } from "./storage.js";
-import type { AuthContextValue, AuthUser, AuthTokens, IdTokenClaims } from "./types.js";
+import type { AuthContextValue, AuthUser, AuthTokens, IdTokenClaims, LoginOptions } from "./types.js";
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 interface AuthProviderProps {
   config: OidcConfig;
   fetchProfile?: boolean;
+  onLogin?: (returnTo: string) => void;
+  onError?: (error: Error) => void;
   children: ReactNode;
 }
 
-const EMPTY_TOKENS: AuthTokens = { access: null, id: null, refresh: null };
+const EMPTY_TOKENS: AuthTokens = { access: null, id: null, refresh: null, expiresAt: null };
+
+function extractExpiresAt(accessToken: string): number | null {
+  try {
+    const payload = decodeJwtPayload(accessToken);
+    if (typeof payload.exp === "number") return payload.exp * 1000;
+  } catch {}
+  return null;
+}
 
 export function AuthProvider({
   config,
   fetchProfile = true,
+  onLogin,
+  onError,
   children,
 }: AuthProviderProps) {
   const discoveryRef = useRef<OidcDiscovery | null>(null);
@@ -58,6 +70,12 @@ export function AuthProvider({
 
   const fetchProfileRef = useRef(fetchProfile);
   fetchProfileRef.current = fetchProfile;
+
+  const onLoginRef = useRef(onLogin);
+  onLoginRef.current = onLogin;
+
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
 
   const fetchUserProfile = useCallback(
     async (discovery: OidcDiscovery, accessToken: string, signal?: AbortSignal): Promise<OidcUser> => {
@@ -80,6 +98,17 @@ export function AuthProvider({
         discoveryRef.current = discovery;
 
         const params = new URLSearchParams(window.location.search);
+        if (params.has("error")) {
+          const description = params.get("error_description") ?? params.get("error")!;
+          const err = new Error(description);
+          setError(err);
+          onErrorRef.current?.(err);
+          clearAuthState();
+          window.history.replaceState({}, "", window.location.pathname);
+          setIsLoading(false);
+          return;
+        }
+
         if (params.has("code") && params.has("state")) {
           const authState = loadAuthState();
           if (!authState) {
@@ -102,6 +131,7 @@ export function AuthProvider({
             access: tokenSet.access_token,
             id: tokenSet.id_token ?? null,
             refresh: tokenSet.refresh_token ?? null,
+            expiresAt: extractExpiresAt(tokenSet.access_token),
           };
           setTokens(newTokens);
 
@@ -115,12 +145,19 @@ export function AuthProvider({
           }
 
           setIsAuthenticated(true);
+          const returnTo = authState.returnTo ?? "/";
           clearAuthState();
-          window.history.replaceState({}, "", window.location.pathname);
+          if (onLoginRef.current) {
+            onLoginRef.current(returnTo);
+          } else {
+            window.history.replaceState({}, "", returnTo);
+          }
         }
       } catch (e) {
         if ((e as Error).name === "AbortError") return;
-        setError(e instanceof Error ? e : new Error(String(e)));
+        const err = e instanceof Error ? e : new Error(String(e));
+        setError(err);
+        onErrorRef.current?.(err);
       } finally {
         if (!signal.aborted) {
           setIsLoading(false);
@@ -132,7 +169,7 @@ export function AuthProvider({
   }, [fetchUserProfile]);
 
   const login = useCallback(
-    async (extraParams?: Record<string, string>) => {
+    async (options?: LoginOptions) => {
       const discovery = discoveryRef.current;
       if (!discovery) return;
 
@@ -140,14 +177,18 @@ export function AuthProvider({
       const state = generateState();
       const nonce = generateNonce();
 
+      const returnTo = options?.returnTo
+        ?? window.location.pathname + window.location.search + window.location.hash;
+
       saveAuthState({
         codeVerifier: pkce.verifier,
         state,
         nonce,
         redirectUri: configRef.current.redirectUri ?? "",
+        returnTo,
       });
 
-      const url = buildAuthUrl(discovery, configRef.current, pkce, state, nonce, extraParams);
+      const url = buildAuthUrl(discovery, configRef.current, pkce, state, nonce, options?.extraParams);
       window.location.href = url;
     },
     [],
@@ -191,6 +232,7 @@ export function AuthProvider({
       access: tokenSet.access_token,
       id: tokenSet.id_token ?? null,
       refresh: tokenSet.refresh_token ?? null,
+      expiresAt: extractExpiresAt(tokenSet.access_token),
     };
     setTokens(newTokens);
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@ export type {
   AuthTokens,
   AuthActions,
   AuthContextValue,
+  LoginOptions,
 } from "./types.js";
 
 export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/react/src/tests/auth-required.test.tsx
+++ b/packages/react/src/tests/auth-required.test.tsx
@@ -9,7 +9,7 @@ vi.mock("../context.js", () => ({
   useAuth: () => mockUseAuth(),
 }));
 
-const EMPTY_TOKENS = { access: null, id: null, refresh: null };
+const EMPTY_TOKENS = { access: null, id: null, refresh: null, expiresAt: null };
 
 function makeActions(overrides: Partial<AuthContextValue["actions"]> = {}) {
   return {
@@ -45,7 +45,9 @@ afterEach(() => {
 
 describe("RequireAuth", () => {
   it("renders children when authenticated", () => {
-    mockUseAuth.mockReturnValue(makeAuth({ isAuthenticated: true }));
+    mockUseAuth.mockReturnValue(
+      makeAuth({ isAuthenticated: true, tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 } }),
+    );
 
     render(
       <RequireAuth>
@@ -103,6 +105,46 @@ describe("RequireAuth", () => {
     await waitFor(() => {
       expect(actions.login).toHaveBeenCalled();
     });
+  });
+
+  it("triggers refresh when access token is expired", async () => {
+    const actions = makeActions({
+      refresh: vi.fn().mockResolvedValue(undefined),
+    });
+    mockUseAuth.mockReturnValue(
+      makeAuth({
+        isAuthenticated: true,
+        tokens: { access: "expired", id: null, refresh: "valid-refresh", expiresAt: Date.now() - 60_000 },
+        actions,
+      }),
+    );
+
+    render(
+      <RequireAuth>
+        <div>Protected</div>
+      </RequireAuth>,
+    );
+
+    await waitFor(() => {
+      expect(actions.refresh).toHaveBeenCalled();
+    });
+  });
+
+  it("renders children when token is not expired", () => {
+    mockUseAuth.mockReturnValue(
+      makeAuth({
+        isAuthenticated: true,
+        tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 },
+      }),
+    );
+
+    render(
+      <RequireAuth>
+        <div>Protected</div>
+      </RequireAuth>,
+    );
+
+    expect(screen.getByText("Protected")).toBeDefined();
   });
 
   it("renders fallback while refreshing", async () => {

--- a/packages/react/src/tests/context.test.tsx
+++ b/packages/react/src/tests/context.test.tsx
@@ -142,7 +142,7 @@ describe("AuthProvider", () => {
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.user).toBeNull();
     expect(result.current.error).toBeNull();
-    expect(result.current.tokens).toEqual({ access: null, id: null, refresh: null });
+    expect(result.current.tokens).toEqual({ access: null, id: null, refresh: null, expiresAt: null });
   });
 
   it("exposes config in context", async () => {
@@ -252,13 +252,59 @@ describe("AuthProvider", () => {
     expect(result.current.error?.message).toContain("Missing auth state");
   });
 
-  it("sets error on discovery fetch failure", async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      statusText: "Internal Server Error",
-      json: () => Promise.reject(new Error("no json")),
+  it("captures IdP error from callback URL and calls onError", async () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "http://localhost:3000?error=access_denied&error_description=User+denied+the+request",
+        search: "?error=access_denied&error_description=User+denied+the+request",
+        pathname: "/",
+      },
+      writable: true,
+      configurable: true,
     });
+
+    sessionStorage.setItem(
+      "oidc-js:auth-state",
+      JSON.stringify({
+        codeVerifier: "test-verifier",
+        state: "test-state",
+        nonce: "test-nonce",
+        redirectUri: "http://localhost:3000/callback",
+      }),
+    );
+
+    mockFetchResponses(DISCOVERY);
+
+    const onError = vi.fn();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <AuthProvider config={CONFIG} onError={onError}>{children}</AuthProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error?.message).toBe("User denied the request");
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: "User denied the request" }));
+    expect(sessionStorage.getItem("oidc-js:auth-state")).toBeNull();
+    expect(window.history.replaceState).toHaveBeenCalled();
+  });
+
+  it("captures IdP error without description", async () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "http://localhost:3000?error=server_error",
+        search: "?error=server_error",
+        pathname: "/",
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    mockFetchResponses(DISCOVERY);
 
     const { result } = renderHook(() => useAuth(), { wrapper });
 
@@ -266,7 +312,30 @@ describe("AuthProvider", () => {
       expect(result.current.isLoading).toBe(false);
     });
 
+    expect(result.current.error?.message).toBe("server_error");
+  });
+
+  it("sets error on discovery fetch failure and calls onError", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.reject(new Error("no json")),
+    });
+
+    const onError = vi.fn();
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <AuthProvider config={CONFIG} onError={onError}>{children}</AuthProvider>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
     expect(result.current.error).not.toBeNull();
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
   });
 
   it("actions.logout clears state", async () => {
@@ -304,6 +373,6 @@ describe("AuthProvider", () => {
 
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.user).toBeNull();
-    expect(result.current.tokens).toEqual({ access: null, id: null, refresh: null });
+    expect(result.current.tokens).toEqual({ access: null, id: null, refresh: null, expiresAt: null });
   });
 });

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -20,10 +20,16 @@ export interface AuthTokens {
   access: string | null;
   id: string | null;
   refresh: string | null;
+  expiresAt: number | null;
+}
+
+export interface LoginOptions {
+  returnTo?: string;
+  extraParams?: Record<string, string>;
 }
 
 export interface AuthActions {
-  login: (extraParams?: Record<string, string>) => void;
+  login: (options?: LoginOptions) => void;
   logout: () => void;
   refresh: () => Promise<void>;
   fetchProfile: () => Promise<void>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,13 +27,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.10(esbuild@0.27.7)
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
       vite-plugin-dts:
         specifier: ^4.0.0
-        version: 4.5.4(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(esbuild@0.27.7))
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
       vitest:
         specifier: ^4.0.0
-        version: 4.1.5(jsdom@26.1.0)(vite@8.0.10(esbuild@0.27.7))
+        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
 
   packages/react:
     dependencies:
@@ -43,7 +43,7 @@ importers:
     devDependencies:
       '@testing-library/react':
         specifier: ^16.0.0
-        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -58,19 +58,59 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.10(esbuild@0.27.7)
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
       vite-plugin-dts:
         specifier: ^4.0.0
-        version: 4.5.4(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(esbuild@0.27.7))
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
       vitest:
         specifier: ^4.0.0
-        version: 4.1.5(jsdom@26.1.0)(vite@8.0.10(esbuild@0.27.7))
+        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
 
   packages/solid: {}
 
   packages/svelte: {}
 
   packages/vue: {}
+
+  tests/e2e:
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.50.0
+        version: 1.59.1
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
+
+  tests/e2e/react-app:
+    dependencies:
+      oidc-js-core:
+        specifier: workspace:*
+        version: link:../../../packages/core
+      oidc-js-react:
+        specifier: workspace:*
+        version: link:../../../packages/react
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.0.0
+        version: 4.7.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
 
 packages:
 
@@ -81,6 +121,40 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -89,13 +163,41 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -354,8 +456,21 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@microsoft/api-extractor-model@7.33.8':
     resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
@@ -378,6 +493,11 @@ packages:
 
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
@@ -467,6 +587,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
@@ -666,6 +789,18 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -680,6 +815,14 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -742,6 +885,12 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.1':
     resolution: {integrity: sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -865,12 +1014,25 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  baseline-browser-mapping@2.10.24:
+    resolution: {integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -936,6 +1098,9 @@ packages:
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
+  electron-to-chromium@1.5.347:
+    resolution: {integrity: sha512-BqbKWR67PjxFypgOFcDevD6j8N8GCPkSnQQRuqQIBh3GYCwr0xsLqw2EtSn83oq5iTqJ/wabM/YHV7KgvWGz7Q==}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -955,6 +1120,10 @@ packages:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1055,6 +1224,11 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1062,6 +1236,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1147,6 +1325,11 @@ packages:
       canvas:
         optional: true
 
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -1158,6 +1341,11 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
@@ -1253,6 +1441,9 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1288,6 +1479,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -1340,6 +1534,16 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1366,6 +1570,10 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
@@ -1402,6 +1610,10 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -1509,9 +1721,18 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1666,6 +1887,9 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1686,15 +1910,108 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -1865,25 +2182,42 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@microsoft/api-extractor-model@7.33.8':
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@microsoft/api-extractor-model@7.33.8(@types/node@25.6.0)':
     dependencies:
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.58.7':
+  '@microsoft/api-extractor@7.58.7(@types/node@25.6.0)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.33.8
+      '@microsoft/api-extractor-model': 7.33.8(@types/node@25.6.0)
       '@microsoft/tsdoc': 0.16.0
       '@microsoft/tsdoc-config': 0.18.1
-      '@rushstack/node-core-library': 5.23.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
       '@rushstack/rig-package': 0.7.3
-      '@rushstack/terminal': 0.24.0
-      '@rushstack/ts-command-line': 5.3.9
+      '@rushstack/terminal': 0.24.0(@types/node@25.6.0)
+      '@rushstack/ts-command-line': 5.3.9(@types/node@25.6.0)
       diff: 8.0.4
       minimatch: 10.2.3
       resolve: 1.22.12
@@ -1910,6 +2244,10 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.127.0': {}
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
@@ -1959,6 +2297,8 @@ snapshots:
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
@@ -2045,7 +2385,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
-  '@rushstack/node-core-library@5.23.1':
+  '@rushstack/node-core-library@5.23.1(@types/node@25.6.0)':
     dependencies:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
@@ -2055,23 +2395,29 @@ snapshots:
       jju: 1.4.0
       resolve: 1.22.12
       semver: 7.7.4
+    optionalDependencies:
+      '@types/node': 25.6.0
 
-  '@rushstack/problem-matcher@0.2.1': {}
+  '@rushstack/problem-matcher@0.2.1(@types/node@25.6.0)':
+    optionalDependencies:
+      '@types/node': 25.6.0
 
   '@rushstack/rig-package@0.7.3':
     dependencies:
       jju: 1.4.0
       resolve: 1.22.12
 
-  '@rushstack/terminal@0.24.0':
+  '@rushstack/terminal@0.24.0(@types/node@25.6.0)':
     dependencies:
-      '@rushstack/node-core-library': 5.23.1
-      '@rushstack/problem-matcher': 0.2.1
+      '@rushstack/node-core-library': 5.23.1(@types/node@25.6.0)
+      '@rushstack/problem-matcher': 0.2.1(@types/node@25.6.0)
       supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 25.6.0
 
-  '@rushstack/ts-command-line@5.3.9':
+  '@rushstack/ts-command-line@5.3.9(@types/node@25.6.0)':
     dependencies:
-      '@rushstack/terminal': 0.24.0
+      '@rushstack/terminal': 0.24.0(@types/node@25.6.0)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -2091,7 +2437,7 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
-  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
@@ -2099,6 +2445,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
     optionalDependencies:
       '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -2108,6 +2455,27 @@ snapshots:
   '@types/argparse@1.0.38': {}
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -2121,6 +2489,14 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
 
   '@types/react@19.2.14':
     dependencies:
@@ -2217,6 +2593,18 @@ snapshots:
       '@typescript-eslint/types': 8.59.1
       eslint-visitor-keys: 5.0.1
 
+  '@vitejs/plugin-react@4.7.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2226,13 +2614,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(esbuild@0.27.7))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(esbuild@0.27.7)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -2353,6 +2741,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  baseline-browser-mapping@2.10.24: {}
+
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
@@ -2360,6 +2750,16 @@ snapshots:
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.24
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.347
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  caniuse-lite@1.0.30001791: {}
 
   chai@6.2.2: {}
 
@@ -2407,6 +2807,8 @@ snapshots:
 
   dom-accessibility-api@0.5.16: {}
 
+  electron-to-chromium@1.5.347: {}
+
   entities@6.0.1: {}
 
   entities@7.0.1: {}
@@ -2444,6 +2846,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
     optional: true
+
+  escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -2555,10 +2959,15 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -2649,6 +3058,8 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jsesc@3.1.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -2656,6 +3067,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  json5@2.2.3: {}
 
   jsonfile@6.2.1:
     dependencies:
@@ -2735,6 +3148,10 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -2767,6 +3184,8 @@ snapshots:
   nanoid@3.3.12: {}
 
   natural-compare@1.4.0: {}
+
+  node-releases@2.0.38: {}
 
   nwsapi@2.2.23: {}
 
@@ -2819,6 +3238,14 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss@8.5.13:
     dependencies:
       nanoid: 3.3.12
@@ -2843,6 +3270,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
+
+  react-refresh@0.17.0: {}
 
   react@19.2.5: {}
 
@@ -2917,6 +3346,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -2999,15 +3430,23 @@ snapshots:
 
   ufo@1.6.4: {}
 
+  undici-types@7.19.2: {}
+
   universalify@2.0.1: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  vite-plugin-dts@4.5.4(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(esbuild@0.27.7)):
+  vite-plugin-dts@4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)):
     dependencies:
-      '@microsoft/api-extractor': 7.58.7
+      '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
@@ -3018,13 +3457,13 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 8.0.10(esbuild@0.27.7)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@8.0.10(esbuild@0.27.7):
+  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -3032,13 +3471,14 @@ snapshots:
       rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 25.6.0
       esbuild: 0.27.7
       fsevents: 2.3.3
 
-  vitest@4.1.5(jsdom@26.1.0)(vite@8.0.10(esbuild@0.27.7)):
+  vitest@4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(esbuild@0.27.7))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -3055,9 +3495,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(esbuild@0.27.7)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.6.0
       jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
@@ -3097,5 +3538,7 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,4 @@
 packages:
   - "packages/*"
+  - "tests/e2e"
+  - "tests/e2e/react-app"

--- a/tests/e2e/.gitignore
+++ b/tests/e2e/.gitignore
@@ -1,0 +1,3 @@
+.autentico/
+test-results/
+playwright-report/

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -19,7 +19,7 @@ async function waitForHealthy(url: string, timeoutMs = 15_000) {
     try {
       const res = await fetch(url);
       if (res.ok) return;
-    } catch {}
+    } catch { /* server not ready */ }
     await new Promise((r) => setTimeout(r, 500));
   }
   throw new Error(`Autentico did not become healthy within ${timeoutMs}ms`);

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,0 +1,143 @@
+import { execSync, spawn } from "child_process";
+import { existsSync, writeFileSync, mkdirSync, rmSync, chmodSync } from "fs";
+import { join } from "path";
+
+const AUTENTICO_DIR = join(import.meta.dirname, ".autentico");
+const AUTENTICO_BIN = join(AUTENTICO_DIR, "autentico");
+const AUTENTICO_RELEASE = "https://github.com/eugenioenko/autentico/releases/download/v1.6.18/autentico-linux-amd64";
+const AUTENTICO_URL = "http://localhost:9999";
+const ADMIN_USER = "admin";
+const ADMIN_PASS = "TestAdmin123!";
+const ADMIN_EMAIL = "admin@test.com";
+const TEST_USER = "testuser";
+const TEST_PASS = "TestUser123!";
+const TEST_EMAIL = "testuser@test.com";
+
+async function waitForHealthy(url: string, timeoutMs = 15_000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Autentico did not become healthy within ${timeoutMs}ms`);
+}
+
+async function getAdminToken(): Promise<string> {
+  const res = await fetch(`${AUTENTICO_URL}/oauth2/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "password",
+      username: ADMIN_USER,
+      password: ADMIN_PASS,
+      client_id: "autentico-admin",
+      scope: "openid",
+    }),
+  });
+  if (!res.ok) throw new Error(`Failed to get admin token: ${res.status} ${await res.text()}`);
+  const data = (await res.json()) as { access_token: string };
+  return data.access_token;
+}
+
+async function registerTestClient(token: string) {
+  const res = await fetch(`${AUTENTICO_URL}/admin/api/clients`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      client_id: "e2e-test-app",
+      client_name: "E2E Test App",
+      redirect_uris: ["http://localhost:5173/callback"],
+      post_logout_redirect_uris: ["http://localhost:5173"],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      scopes: "openid profile email offline_access",
+      client_type: "public",
+      token_endpoint_auth_method: "none",
+    }),
+  });
+  if (!res.ok) throw new Error(`Failed to register client: ${res.status} ${await res.text()}`);
+}
+
+async function createTestUser(token: string) {
+  const res = await fetch(`${AUTENTICO_URL}/admin/api/users`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      username: TEST_USER,
+      password: TEST_PASS,
+      email: TEST_EMAIL,
+    }),
+  });
+  if (!res.ok) throw new Error(`Failed to create test user: ${res.status} ${await res.text()}`);
+}
+
+async function configureCors(token: string) {
+  const res = await fetch(`${AUTENTICO_URL}/admin/api/settings`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      cors_allowed_origins: "*",
+    }),
+  });
+  if (!res.ok) throw new Error(`Failed to configure CORS: ${res.status} ${await res.text()}`);
+}
+
+export default async function globalSetup() {
+  // Clean previous state
+  if (existsSync(AUTENTICO_DIR)) {
+    rmSync(AUTENTICO_DIR, { recursive: true });
+  }
+  mkdirSync(AUTENTICO_DIR, { recursive: true });
+
+  // Download autentico binary from release
+  if (!existsSync(AUTENTICO_BIN)) {
+    console.log("Downloading autentico...");
+    execSync(`curl -fsSL -o ${AUTENTICO_BIN} ${AUTENTICO_RELEASE}`, { stdio: "inherit" });
+    chmodSync(AUTENTICO_BIN, 0o755);
+  }
+
+  // Init and onboard
+  console.log("Initializing autentico...");
+  execSync(`${AUTENTICO_BIN} init --url ${AUTENTICO_URL}`, { cwd: AUTENTICO_DIR, stdio: "inherit" });
+  execSync(
+    `${AUTENTICO_BIN} onboard --username ${ADMIN_USER} --password "${ADMIN_PASS}" --email ${ADMIN_EMAIL} --enable-admin-password-grant`,
+    { cwd: AUTENTICO_DIR, stdio: "inherit" },
+  );
+
+  // Start autentico
+  console.log("Starting autentico...");
+  const proc = spawn(AUTENTICO_BIN, ["start"], {
+    cwd: AUTENTICO_DIR,
+    stdio: "pipe",
+    detached: true,
+  });
+  proc.unref();
+
+  // Save PID for teardown
+  writeFileSync(join(AUTENTICO_DIR, "pid"), String(proc.pid));
+
+  // Wait for healthy
+  await waitForHealthy(`${AUTENTICO_URL}/.well-known/openid-configuration`);
+  console.log("Autentico is ready");
+
+  // Setup test data
+  const token = await getAdminToken();
+  await registerTestClient(token);
+  console.log("Registered e2e-test-app client");
+  await createTestUser(token);
+  console.log("Created test user");
+  await configureCors(token);
+  console.log("Configured CORS");
+}

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,0 +1,21 @@
+import { readFileSync, existsSync, rmSync } from "fs";
+import { join } from "path";
+
+const AUTENTICO_DIR = join(import.meta.dirname, ".autentico");
+
+export default async function globalTeardown() {
+  const pidFile = join(AUTENTICO_DIR, "pid");
+  if (existsSync(pidFile)) {
+    const pid = parseInt(readFileSync(pidFile, "utf-8").trim());
+    try {
+      process.kill(pid, "SIGTERM");
+      console.log(`Stopped autentico (PID ${pid})`);
+    } catch {
+      // Already dead
+    }
+  }
+
+  if (existsSync(AUTENTICO_DIR)) {
+    rmSync(AUTENTICO_DIR, { recursive: true });
+  }
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "e2e-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0",
+    "@types/node": "^25.6.0"
+  }
+}

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./specs",
+  timeout: 30_000,
+  retries: 0,
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+  globalSetup: "./global-setup.ts",
+  globalTeardown: "./global-teardown.ts",
+  webServer: {
+    command: "pnpm --dir react-app dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 15_000,
+  },
+});

--- a/tests/e2e/react-app/index.html
+++ b/tests/e2e/react-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OIDC E2E Test App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/tests/e2e/react-app/package.json
+++ b/tests/e2e/react-app/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "e2e-react-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "oidc-js-core": "workspace:*",
+    "oidc-js-react": "workspace:*",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^8.0.0"
+  }
+}

--- a/tests/e2e/react-app/src/App.tsx
+++ b/tests/e2e/react-app/src/App.tsx
@@ -1,0 +1,77 @@
+import { useState, useEffect } from "react";
+import { useAuth, RequireAuth } from "oidc-js-react";
+
+function HomePage() {
+  const { user, isAuthenticated, isLoading, error, tokens, actions } = useAuth();
+
+  if (isLoading) {
+    return <div data-testid="loading">Loading...</div>;
+  }
+
+  if (error) {
+    return <div data-testid="error">Error: {error.message}</div>;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div data-testid="unauthenticated">
+        <h1>Not logged in</h1>
+        <button data-testid="login-button" onClick={() => actions.login()}>
+          Login
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="authenticated">
+      <h1>Logged in</h1>
+      <div data-testid="user-sub">{user?.claims.sub}</div>
+      <div data-testid="user-iss">{user?.claims.iss}</div>
+      <div data-testid="user-aud">{typeof user?.claims.aud === "string" ? user.claims.aud : JSON.stringify(user?.claims.aud)}</div>
+      <div data-testid="user-exp">{user?.claims.exp}</div>
+      <div data-testid="user-iat">{user?.claims.iat}</div>
+      <div data-testid="user-email">{user?.profile?.email ?? "no profile"}</div>
+      <div data-testid="user-profile-null">{user?.profile === null ? "true" : "false"}</div>
+      <div data-testid="access-token">{tokens.access ? "present" : "missing"}</div>
+      <div data-testid="refresh-token">{tokens.refresh ? "present" : "missing"}</div>
+      <div data-testid="id-token">{tokens.id ? "present" : "missing"}</div>
+      <div data-testid="expires-at">{tokens.expiresAt ?? "none"}</div>
+      <button data-testid="logout-button" onClick={() => actions.logout()}>
+        Logout
+      </button>
+      <button data-testid="refresh-button" onClick={() => actions.refresh().catch(() => {})}>
+        Refresh
+      </button>
+    </div>
+  );
+}
+
+function ProtectedPage({ name }: { name: string }) {
+  return (
+    <RequireAuth fallback={<div data-testid="require-auth-loading">Refreshing...</div>}>
+      <div data-testid={`protected-${name}`}>
+        Protected content {name}
+      </div>
+    </RequireAuth>
+  );
+}
+
+export function App() {
+  const [hash, setHash] = useState(window.location.hash);
+
+  useEffect(() => {
+    const onHashChange = () => setHash(window.location.hash);
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
+  }, []);
+
+  switch (hash) {
+    case "#/protected-a":
+      return <ProtectedPage name="a" />;
+    case "#/protected-b":
+      return <ProtectedPage name="b" />;
+    default:
+      return <HomePage />;
+  }
+}

--- a/tests/e2e/react-app/src/main.tsx
+++ b/tests/e2e/react-app/src/main.tsx
@@ -1,0 +1,19 @@
+import { createRoot } from "react-dom/client";
+import { AuthProvider } from "oidc-js-react";
+import { App } from "./App.js";
+
+const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+
+const config = {
+  issuer: "http://localhost:9999/oauth2",
+  clientId: "e2e-test-app",
+  redirectUri: "http://localhost:5173/callback",
+  scopes: ["openid", "profile", "email", "offline_access"],
+  postLogoutRedirectUri: "http://localhost:5173",
+};
+
+createRoot(document.getElementById("root")!).render(
+  <AuthProvider config={config} fetchProfile={fetchProfile}>
+    <App />
+  </AuthProvider>,
+);

--- a/tests/e2e/react-app/tsconfig.json
+++ b/tests/e2e/react-app/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/tests/e2e/react-app/vite.config.ts
+++ b/tests/e2e/react-app/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
+});

--- a/tests/e2e/specs/login.spec.ts
+++ b/tests/e2e/specs/login.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect } from "@playwright/test";
+
+const AUTENTICO_URL = "http://localhost:9999";
+const TEST_USER = "testuser";
+const TEST_PASS = "TestUser123!";
+const ADMIN_USER = "admin";
+const ADMIN_PASS = "TestAdmin123!";
+
+async function login(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.getByTestId("login-button").click();
+  await page.waitForURL(/localhost:9999/);
+  await page.fill('input[name="username"]', TEST_USER);
+  await page.fill('input[name="password"]', TEST_PASS);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/localhost:5173/);
+  await expect(page.getByTestId("authenticated")).toBeVisible();
+}
+
+async function getAdminToken(): Promise<string> {
+  const res = await fetch(`${AUTENTICO_URL}/oauth2/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "password",
+      username: ADMIN_USER,
+      password: ADMIN_PASS,
+      client_id: "autentico-admin",
+      scope: "openid",
+    }),
+  });
+  const data = (await res.json()) as { access_token: string };
+  return data.access_token;
+}
+
+async function setClientTokenExpiration(expiration: string | null) {
+  const token = await getAdminToken();
+  await fetch(`${AUTENTICO_URL}/admin/api/clients/e2e-test-app`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      access_token_expiration: expiration,
+    }),
+  });
+}
+
+test.describe("OIDC Login Flow", () => {
+  test("shows login button when not authenticated", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByTestId("unauthenticated")).toBeVisible();
+    await expect(page.getByTestId("login-button")).toBeVisible();
+  });
+
+  test("completes full login flow with tokens", async ({ page }) => {
+    await login(page);
+    await expect(page.getByTestId("access-token")).toHaveText("present");
+    await expect(page.getByTestId("refresh-token")).toHaveText("present");
+    await expect(page.getByTestId("id-token")).toHaveText("present");
+  });
+
+  test("user.claims has required OIDC fields", async ({ page }) => {
+    await login(page);
+    await expect(page.getByTestId("user-sub")).not.toBeEmpty();
+    await expect(page.getByTestId("user-iss")).toHaveText("http://localhost:9999/oauth2");
+    await expect(page.getByTestId("user-aud")).not.toBeEmpty();
+    await expect(page.getByTestId("user-exp")).not.toBeEmpty();
+    await expect(page.getByTestId("user-iat")).not.toBeEmpty();
+  });
+
+  test("user.profile is populated when fetchProfile is true", async ({ page }) => {
+    await login(page);
+    await expect(page.getByTestId("user-email")).toHaveText("testuser@test.com");
+    await expect(page.getByTestId("user-profile-null")).toHaveText("false");
+  });
+
+  test("user.profile is null when fetchProfile is false", async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(() => localStorage.setItem("e2e-fetchProfile", "false"));
+    await page.reload();
+    await page.getByTestId("login-button").click();
+    await page.waitForURL(/localhost:9999/);
+    await page.fill('input[name="username"]', TEST_USER);
+    await page.fill('input[name="password"]', TEST_PASS);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(/localhost:5173/);
+    await expect(page.getByTestId("authenticated")).toBeVisible();
+    await expect(page.getByTestId("user-profile-null")).toHaveText("true");
+    await expect(page.getByTestId("user-email")).toHaveText("no profile");
+    await page.evaluate(() => localStorage.removeItem("e2e-fetchProfile"));
+  });
+
+  test("logout clears state", async ({ page }) => {
+    await login(page);
+    await page.getByTestId("logout-button").click();
+    await page.waitForURL(/localhost/);
+    await page.goto("/");
+    await expect(page.getByTestId("unauthenticated")).toBeVisible();
+  });
+
+  test("manual token refresh", async ({ page }) => {
+    await login(page);
+    const oldExpiresAt = await page.getByTestId("expires-at").textContent();
+    // Small delay so new token gets a different exp
+    await page.waitForTimeout(1000);
+    await page.getByTestId("refresh-button").click();
+    await expect(page.getByTestId("authenticated")).toBeVisible();
+    await expect(page.getByTestId("expires-at")).not.toHaveText(oldExpiresAt!);
+  });
+});
+
+test.describe("RequireAuth", () => {
+  test("shows protected content when authenticated", async ({ page }) => {
+    await login(page);
+    await page.evaluate(() => (window.location.hash = "#/protected-a"));
+    await expect(page.getByTestId("protected-a")).toBeVisible();
+  });
+
+  test("auto-refreshes expired token when navigating to protected page", async ({ page }) => {
+    await setClientTokenExpiration("1s");
+    try {
+      await login(page);
+      await page.evaluate(() => (window.location.hash = "#/protected-a"));
+      await expect(page.getByTestId("protected-a")).toBeVisible();
+
+      // Wait for token to expire
+      await page.waitForTimeout(5000);
+
+      // Navigate to second protected page — RequireAuth should auto-refresh
+      await page.evaluate(() => (window.location.hash = "#/protected-b"));
+      await expect(page.getByTestId("protected-b")).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await setClientTokenExpiration(null);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **E2E test harness** using Autentico as a real OIDC IdP — downloads release binary, bootstraps a fresh instance per run, tears down after tests
- **9 Playwright E2E tests**: unauthenticated state, login flow with tokens, user.claims validation (sub/iss/aud/exp/iat), user.profile with fetchProfile=true, user.profile null with fetchProfile=false, logout, manual token refresh, RequireAuth protected content, RequireAuth auto-refresh with expired token (1s TTL, 5s wait)
- **RequireAuth checks `tokens.expiresAt`** — decoded once from access token JWT on token exchange, compared on render instead of re-decoding every time
- **`onLogin(returnTo)` callback** — captures current URL before login redirect, restores after callback; defaults to `replaceState` when no callback provided
- **`onError(error)` callback** — fires on IdP errors, discovery failures, and token exchange failures
- **IdP error capture** — detects `?error=` param in callback URL (RFC 6749 §4.1.2.1)
- **`LoginOptions` type** — `{ returnTo?, extraParams? }` replaces bare `Record<string, string>`
- **CI updated** — Playwright browser caching, E2E test step
- **Decisions 012–019** documented

## Test plan

- [x] 28 unit tests pass (React package)
- [x] 9 E2E tests pass locally (Playwright + Autentico)
- [ ] CI passes (Playwright browser download + Autentico binary on ubuntu-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)