### PR TITLE
fix: set site and base URL for GitHub Pages

### DIFF
--- a/docs-web/astro.config.mjs
+++ b/docs-web/astro.config.mjs
@@ -6,6 +6,8 @@ import sitemap from '@astrojs/sitemap';
 import starlightThemeGalaxy from 'starlight-theme-galaxy';
 
 export default defineConfig({
+	site: 'https://eugenioenko.github.io',
+	base: '/oidc-js',
 	integrations: [
 		sitemap(),
 		starlight({


### PR DESCRIPTION
## Summary
- Add `site` and `base` to `astro.config.mjs` so assets resolve correctly under the `/oidc-js/` subpath on GitHub Pages

## Test plan
- [ ] Verify CSS/JS loads at https://eugenioenko.github.io/oidc-js/ after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)