### PR TITLE
fix: add base path to hero quickstart link

### DIFF
--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ hero:
   tagline: Zero-dependency OIDC client for JavaScript & TypeScript.
   actions:
     - text: Quickstart
-      link: /getting-started/quickstart/
+      link: /oidc-js/getting-started/quickstart/
       icon: right-arrow
       variant: primary
     - text: GitHub


### PR DESCRIPTION
## Summary
- Fix hero "Quickstart" link missing `/oidc-js` base path, causing 404 on GitHub Pages

## Test plan
- [ ] Hero quickstart link navigates to `/oidc-js/getting-started/quickstart/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)