### PR TITLE
feat: add TSDoc comments and auto-generated API reference

### DIFF
--- a/docs-web/.gitignore
+++ b/docs-web/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 .astro/
+src/content/docs/api/

--- a/docs-web/astro.config.mjs
+++ b/docs-web/astro.config.mjs
@@ -2,6 +2,7 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import starlightClientMermaid from '@pasqal-io/starlight-client-mermaid';
+import starlightTypeDoc from 'starlight-typedoc';
 import sitemap from '@astrojs/sitemap';
 import starlightThemeGalaxy from 'starlight-theme-galaxy';
 
@@ -23,7 +24,36 @@ export default defineConfig({
 			editLink: {
 				baseUrl: 'https://github.com/eugenioenko/oidc-js/edit/main/docs-web/',
 			},
-			plugins: [starlightThemeGalaxy(), starlightClientMermaid()],
+			plugins: [
+				starlightThemeGalaxy(),
+				starlightClientMermaid(),
+				starlightTypeDoc({
+					entryPoints: ['../packages/core/src/index.ts'],
+					tsconfig: '../packages/core/tsconfig.json',
+					output: 'api/core',
+					sidebar: {
+						label: 'API Reference (Core)',
+						collapsed: true,
+					},
+					typeDoc: {
+						excludePrivate: true,
+						excludeInternal: true,
+					},
+				}),
+				starlightTypeDoc({
+					entryPoints: ['../packages/client/src/index.ts'],
+					tsconfig: '../packages/client/tsconfig.json',
+					output: 'api/client',
+					sidebar: {
+						label: 'API Reference (Client)',
+						collapsed: true,
+					},
+					typeDoc: {
+						excludePrivate: true,
+						excludeInternal: true,
+					},
+				}),
+			],
 			sidebar: [
 				{ label: 'Introduction', link: '/' },
 				{

--- a/docs-web/package.json
+++ b/docs-web/package.json
@@ -16,6 +16,9 @@
     "@pasqal-io/starlight-client-mermaid": "^0.1.0",
     "astro": "^5.6.1",
     "sharp": "^0.34.2",
-    "starlight-theme-galaxy": "^0.7.0"
+    "starlight-theme-galaxy": "^0.7.0",
+    "starlight-typedoc": "^0.21.5",
+    "typedoc": "^0.28.19",
+    "typedoc-plugin-markdown": "^4.11.0"
   }
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -20,10 +20,17 @@ import { executeFetch } from "./fetch.js";
 import { saveAuthState, loadAuthState, clearAuthState } from "./storage.js";
 import type { OidcClientConfig, AuthState, AuthUser, AuthTokens, IdTokenClaims, LoginOptions } from "./types.js";
 
+/** Callback invoked whenever the {@link AuthState} changes. */
 type Subscriber = (state: AuthState) => void;
 
 const EMPTY_TOKENS: AuthTokens = { access: null, id: null, refresh: null, expiresAt: null };
 
+/**
+ * Extracts the `exp` claim from an access token JWT and converts it to milliseconds.
+ *
+ * @param accessToken - A JWT access token string.
+ * @returns The expiration time in milliseconds, or null if the token cannot be decoded.
+ */
 function extractExpiresAt(accessToken: string): number | null {
   try {
     const payload = decodeJwtPayload(accessToken);
@@ -32,6 +39,13 @@ function extractExpiresAt(accessToken: string): number | null {
   return null;
 }
 
+/**
+ * Browser OIDC client that wraps oidc-js-core with `fetch` and `sessionStorage`.
+ *
+ * Handles the full Authorization Code + PKCE flow: discovery, redirect-based login,
+ * callback handling, token refresh, userinfo fetching, and logout.
+ * Exposes reactive {@link AuthState} via a subscribe/notify pattern.
+ */
 export class OidcClient {
   private config: OidcClientConfig;
   private discovery: OidcDiscovery | null = null;
@@ -46,19 +60,34 @@ export class OidcClient {
     tokens: EMPTY_TOKENS,
   };
 
+  /**
+   * Creates a new OidcClient instance.
+   *
+   * @param config - OIDC configuration including issuer, clientId, and redirectUri.
+   */
   constructor(config: OidcClientConfig) {
     this.config = config;
   }
 
+  /** The current authentication state. */
   get state(): AuthState {
     return this._state;
   }
 
+  /**
+   * Registers a callback that fires whenever the auth state changes.
+   *
+   * @param fn - Subscriber function receiving the updated {@link AuthState}.
+   * @returns An unsubscribe function that removes the listener.
+   */
   subscribe(fn: Subscriber): () => void {
     this.subscribers.add(fn);
     return () => this.subscribers.delete(fn);
   }
 
+  /**
+   * Merges a partial state update into the current state and notifies all subscribers.
+   */
   private setState(partial: Partial<AuthState>) {
     this._state = { ...this._state, ...partial };
     for (const fn of this.subscribers) {
@@ -66,6 +95,15 @@ export class OidcClient {
     }
   }
 
+  /**
+   * Initializes the client by fetching OIDC discovery and processing any callback parameters.
+   *
+   * If the current URL contains an authorization code, it completes the token exchange,
+   * optionally fetches the userinfo profile, and returns the `returnTo` path saved before login.
+   * If the URL contains an error, it sets the error state.
+   *
+   * @returns An object with an optional `returnTo` path indicating where the app should navigate.
+   */
   async init(): Promise<{ returnTo?: string }> {
     this.abortController = new AbortController();
     const { signal } = this.abortController;
@@ -138,6 +176,14 @@ export class OidcClient {
     }
   }
 
+  /**
+   * Starts the Authorization Code + PKCE login flow by redirecting the browser to the authorization endpoint.
+   *
+   * Generates PKCE, state, and nonce values, persists them in sessionStorage, then navigates away.
+   * Does nothing if discovery has not been fetched yet (i.e., {@link init} was not called).
+   *
+   * @param options - Optional login parameters such as `returnTo` and `extraParams`.
+   */
   async login(options?: LoginOptions): Promise<void> {
     if (!this.discovery) return;
 
@@ -160,6 +206,12 @@ export class OidcClient {
     window.location.href = url;
   }
 
+  /**
+   * Logs the user out by clearing local auth state and redirecting to the OP's end-session endpoint.
+   *
+   * If the discovery document has an `end_session_endpoint`, the browser is redirected there
+   * with the current ID token hint and `postLogoutRedirectUri` from config.
+   */
   logout(): void {
     const idToken = this._state.tokens.id;
 
@@ -182,6 +234,14 @@ export class OidcClient {
     }
   }
 
+  /**
+   * Uses the stored refresh token to obtain a new set of tokens from the token endpoint.
+   *
+   * Updates the auth state with the new tokens and, if an ID token is returned,
+   * re-decodes the claims and optionally re-fetches the userinfo profile.
+   *
+   * @throws Error if no refresh token is available or discovery has not been fetched.
+   */
   async refresh(): Promise<void> {
     const refreshToken = this._state.tokens.refresh;
 
@@ -218,6 +278,13 @@ export class OidcClient {
     });
   }
 
+  /**
+   * Fetches the user's profile from the userinfo endpoint using the current access token.
+   *
+   * Updates the `user.profile` field in the auth state with the response.
+   *
+   * @throws Error if no access token is available or discovery has not been fetched.
+   */
   async fetchProfile(): Promise<void> {
     if (!this.discovery || !this._state.tokens.access) {
       throw new Error("No access token available");
@@ -229,11 +296,21 @@ export class OidcClient {
     }
   }
 
+  /**
+   * Tears down the client by aborting any in-flight requests and removing all subscribers.
+   */
   destroy(): void {
     this.abortController?.abort();
     this.subscribers.clear();
   }
 
+  /**
+   * Internal helper that calls the userinfo endpoint and parses the response.
+   *
+   * @param accessToken - Bearer token to authorize the request.
+   * @param signal - Optional abort signal for cancellation.
+   * @returns The parsed userinfo response.
+   */
   private async fetchProfileInternal(accessToken: string, signal?: AbortSignal): Promise<OidcUser> {
     const req = buildUserinfoRequest(this.discovery!, accessToken);
     const data = await executeFetch(req, signal);

--- a/packages/client/src/fetch.ts
+++ b/packages/client/src/fetch.ts
@@ -1,5 +1,13 @@
 import type { HttpRequest } from "oidc-js-core";
 
+/**
+ * Executes an HTTP request built by oidc-js-core and returns the parsed JSON response.
+ * Throws on non-OK responses, surfacing OAuth 2.0 error descriptions when available.
+ *
+ * @param request - The {@link HttpRequest} descriptor (url, method, headers, body) from a core builder function.
+ * @param signal - Optional `AbortSignal` to cancel the request.
+ * @returns The parsed JSON response body.
+ */
 export async function executeFetch(
   request: HttpRequest,
   signal?: AbortSignal,

--- a/packages/client/src/storage.ts
+++ b/packages/client/src/storage.ts
@@ -2,10 +2,20 @@ import type { AuthState } from "oidc-js-core";
 
 const STORAGE_KEY = "oidc-js:auth-state";
 
+/**
+ * Persists the PKCE and OIDC auth state to `sessionStorage` so it survives the authorization redirect.
+ *
+ * @param authState - The auth state containing code verifier, state, nonce, and redirect URI.
+ */
 export function saveAuthState(authState: AuthState): void {
   sessionStorage.setItem(STORAGE_KEY, JSON.stringify(authState));
 }
 
+/**
+ * Loads the previously saved auth state from `sessionStorage`.
+ *
+ * @returns The parsed auth state, or null if nothing is stored or the value is malformed.
+ */
 export function loadAuthState(): AuthState | null {
   const raw = sessionStorage.getItem(STORAGE_KEY);
   if (!raw) return null;
@@ -16,6 +26,9 @@ export function loadAuthState(): AuthState | null {
   }
 }
 
+/**
+ * Removes the auth state from `sessionStorage`, typically after a successful token exchange.
+ */
 export function clearAuthState(): void {
   sessionStorage.removeItem(STORAGE_KEY);
 }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,40 +1,79 @@
 import type { OidcConfig, OidcUser } from "oidc-js-core";
 
+/**
+ * Decoded claims from an ID token payload per RFC 7519 and OpenID Connect Core section 2.
+ */
 export interface IdTokenClaims {
+  /** Subject identifier for the end-user. */
   sub: string;
+  /** Issuer identifier (URL) of the token. */
   iss: string;
+  /** Audience(s) the token is intended for. */
   aud: string | string[];
+  /** Expiration time as a Unix timestamp in seconds. */
   exp: number;
+  /** Issued-at time as a Unix timestamp in seconds. */
   iat: number;
+  /** Nonce value used to associate a client session with an ID token. */
   nonce?: string;
+  /** Additional claims present in the token. */
   [claim: string]: unknown;
 }
 
+/**
+ * Represents the authenticated user, combining ID token claims with an optional userinfo profile.
+ */
 export interface AuthUser {
+  /** Decoded claims from the ID token. */
   claims: IdTokenClaims;
+  /** Userinfo endpoint response, or null if not fetched. */
   profile: OidcUser | null;
 }
 
+/**
+ * Holds the current set of OAuth 2.0 tokens obtained from the authorization server.
+ */
 export interface AuthTokens {
+  /** The access token string, or null if not yet obtained. */
   access: string | null;
+  /** The ID token string, or null if not returned. */
   id: string | null;
+  /** The refresh token string, or null if not returned. */
   refresh: string | null;
+  /** Access token expiration as a Unix timestamp in milliseconds, or null if unknown. */
   expiresAt: number | null;
 }
 
+/**
+ * Options for the {@link OidcClient.login} method.
+ */
 export interface LoginOptions {
+  /** URL to redirect the user back to after login completes. Defaults to the current location. */
   returnTo?: string;
+  /** Additional query parameters to include in the authorization request. */
   extraParams?: Record<string, string>;
 }
 
+/**
+ * Configuration for {@link OidcClient}, extending the core `OidcConfig` with client-specific options.
+ */
 export interface OidcClientConfig extends OidcConfig {
+  /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
   fetchProfile?: boolean;
 }
 
+/**
+ * Reactive authentication state exposed by {@link OidcClient}.
+ */
 export interface AuthState {
+  /** The authenticated user, or null if not logged in. */
   user: AuthUser | null;
+  /** Whether the user is currently authenticated. */
   isAuthenticated: boolean;
+  /** Whether initialization or a token exchange is in progress. */
   isLoading: boolean;
+  /** The most recent authentication error, or null if none. */
   error: Error | null;
+  /** Current set of OAuth 2.0 tokens. */
   tokens: AuthTokens;
 }

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,5 +1,14 @@
 import type { OidcConfig } from "./types.js";
 
+/**
+ * Builds HTTP Basic authentication headers from the client credentials.
+ * Returns an empty object if `clientSecret` is not configured (public client).
+ *
+ * @param config - The OIDC client configuration.
+ * @returns A headers record containing the `Authorization: Basic` header, or an empty record for public clients.
+ *
+ * @see RFC 6749 §2.3.1 -- Client Password (HTTP Basic)
+ */
 // RFC 6749 §2.3.1: HTTP Basic authentication with client_id:client_secret
 export function buildClientAuthHeaders(config: OidcConfig): Record<string, string> {
   if (!config.clientSecret) return {};

--- a/packages/core/src/authorize.ts
+++ b/packages/core/src/authorize.ts
@@ -1,6 +1,25 @@
 import type { OidcConfig, OidcDiscovery } from "./types.js";
 import { OidcError } from "./errors.js";
 
+/**
+ * Builds the full authorization endpoint URL with all required query parameters.
+ *
+ * Includes PKCE challenge, state, nonce, and any caller-supplied extra parameters.
+ * Uses `response_type=code` and `code_challenge_method=S256`.
+ *
+ * @param discovery - The provider's parsed discovery document.
+ * @param config - Client configuration; `redirectUri` is required for this call.
+ * @param pkce - The PKCE verifier/challenge pair (only `challenge` is sent to the provider).
+ * @param state - An opaque CSRF-protection value to round-trip through the callback.
+ * @param nonce - A random value binding the resulting ID token to this session.
+ * @param extraParams - Optional additional query parameters to append to the URL.
+ * @returns The complete authorization URL to redirect the user to.
+ * @throws {OidcError} `MISSING_REDIRECT_URI` if `config.redirectUri` is not set.
+ *
+ * @see RFC 6749 §4.1.1 -- Authorization Request
+ * @see RFC 7636 §4.3 -- code_challenge and code_challenge_method
+ * @see OpenID Connect Core 1.0 §3.1.2.1 -- Authentication Request
+ */
 // RFC 6749 §4.1.1: Authorization Request
 // RFC 7636 §4.3: code_challenge and code_challenge_method
 // OIDC Core §3.1.2.1: scope MUST contain openid, nonce binds session to ID token
@@ -33,6 +52,21 @@ export function buildAuthUrl(
   return `${discovery.authorization_endpoint}?${params.toString()}`;
 }
 
+/**
+ * Parses an OAuth 2.0 authorization callback URL, extracting the authorization code and verifying state.
+ *
+ * Rejects error responses, missing codes, and state mismatches.
+ *
+ * @param url - The full callback URL the provider redirected the user to.
+ * @param expectedState - The state value originally sent in the authorization request.
+ * @returns An object containing the authorization `code` and the validated `state`.
+ * @throws {OidcError} `AUTHORIZATION_ERROR` if the provider returned an error response.
+ * @throws {OidcError} `MISSING_AUTH_CODE` if no `code` parameter is present.
+ * @throws {OidcError} `STATE_MISMATCH` if the returned state does not match `expectedState`.
+ *
+ * @see RFC 6749 §4.1.2 -- Authorization Response
+ * @see RFC 6749 §10.12 -- Cross-Site Request Forgery (state verification)
+ */
 // RFC 6749 §4.1.2: Authorization Response
 // RFC 6749 §10.12: state parameter MUST match for CSRF protection
 export function parseCallbackUrl(url: string, expectedState: string): { code: string; state: string } {

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -3,6 +3,12 @@ import { OidcError } from "./errors.js";
 // RFC 7636 §4.1: unreserved characters for code_verifier
 const UNRESERVED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
 
+/**
+ * Encodes a byte array to a base64url string (no padding), as defined in RFC 4648 Section 5.
+ *
+ * @param bytes - Raw bytes to encode.
+ * @returns Base64url-encoded string without trailing `=` padding.
+ */
 export function base64UrlEncode(bytes: Uint8Array): string {
   let binary = "";
   for (const byte of bytes) {
@@ -11,6 +17,13 @@ export function base64UrlEncode(bytes: Uint8Array): string {
   return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
+/**
+ * Decodes a base64url string back to a byte array.
+ *
+ * @param str - Base64url-encoded string (with or without padding).
+ * @returns Decoded bytes.
+ * @throws {@link OidcError} with code `INVALID_JWT` if the input is not valid base64url.
+ */
 export function base64UrlDecode(str: string): Uint8Array {
   try {
     const padded = str.replace(/-/g, "+").replace(/_/g, "/") + "=".repeat((4 - (str.length % 4)) % 4);
@@ -25,6 +38,14 @@ export function base64UrlDecode(str: string): Uint8Array {
   }
 }
 
+/**
+ * Generates a cryptographically random string from the RFC 7636 unreserved character set.
+ *
+ * Uses rejection sampling to avoid modulo bias when mapping random bytes to the 66-character alphabet.
+ *
+ * @param length - Desired string length (default 32). RFC 7636 Section 4.1 requires at least 43 characters for code verifiers.
+ * @returns A random string of the specified length.
+ */
 // RFC 7636 §4.1: code_verifier has minimum 256 bits of entropy
 // Rejection sampling avoids modulo bias (256 % 66 != 0)
 export function generateRandom(length: number = 32): string {
@@ -43,6 +64,14 @@ export function generateRandom(length: number = 32): string {
   return result;
 }
 
+/**
+ * Computes a PKCE code challenge from a code verifier (RFC 7636 Section 4.2).
+ *
+ * Applies `BASE64URL(SHA-256(ASCII(code_verifier)))` using the Web Crypto API.
+ *
+ * @param verifier - The plaintext code verifier string.
+ * @returns The base64url-encoded SHA-256 challenge.
+ */
 // RFC 7636 §4.2: code_challenge = BASE64URL(SHA256(ASCII(code_verifier)))
 export async function computeCodeChallenge(verifier: string): Promise<string> {
   const encoded = new TextEncoder().encode(verifier);
@@ -50,6 +79,11 @@ export async function computeCodeChallenge(verifier: string): Promise<string> {
   return base64UrlEncode(new Uint8Array(digest));
 }
 
+/**
+ * Generates a PKCE code verifier and its corresponding S256 challenge (RFC 7636 Section 4).
+ *
+ * @returns An object with `verifier` (43-char random string) and `challenge` (base64url SHA-256 hash).
+ */
 // RFC 7636 §4.1: code_verifier = 43-128 unreserved chars
 // RFC 7636 §4.2: code_challenge = BASE64URL(SHA256(code_verifier))
 export async function generatePkce(): Promise<{ verifier: string; challenge: string }> {
@@ -58,11 +92,22 @@ export async function generatePkce(): Promise<{ verifier: string; challenge: str
   return { verifier, challenge };
 }
 
+/**
+ * Generates a random `state` parameter for CSRF protection (RFC 6749 Section 10.12).
+ *
+ * @returns A 32-character random string.
+ */
 // RFC 6749 §10.12: state for CSRF protection
 export function generateState(): string {
   return generateRandom(32);
 }
 
+/**
+ * Generates a random `nonce` to bind an ID token to a client session
+ * (OpenID Connect Core 1.0 Section 3.1.2.1).
+ *
+ * @returns A 32-character random string.
+ */
 // OIDC Core §3.1.2.1: nonce binds client session to ID token
 export function generateNonce(): string {
   return generateRandom(32);

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -1,6 +1,16 @@
 import type { OidcDiscovery } from "./types.js";
 import { OidcError } from "./errors.js";
 
+/**
+ * Constructs the well-known OpenID Provider Configuration URL for the given issuer.
+ *
+ * Trailing slashes on the issuer are stripped before appending the well-known path.
+ *
+ * @param issuer - The OpenID Provider issuer identifier (e.g. `https://accounts.example.com`).
+ * @returns The full `/.well-known/openid-configuration` URL.
+ *
+ * @see OpenID Connect Discovery 1.0 §4.1 -- OpenID Provider Configuration Request
+ */
 // OIDC Discovery §4.1: OpenID Provider Configuration Request
 export function buildDiscoveryUrl(issuer: string): string {
   return `${issuer.replace(/\/+$/, "")}/.well-known/openid-configuration`;
@@ -19,6 +29,20 @@ const REQUIRED_ARRAY_FIELDS: (keyof OidcDiscovery)[] = [
   "id_token_signing_alg_values_supported",
 ];
 
+/**
+ * Validates and parses a raw OpenID Provider Configuration response into an {@link OidcDiscovery} object.
+ *
+ * Checks that all required string and array fields are present, and that the returned issuer
+ * exactly matches `expectedIssuer` (after trailing-slash normalization).
+ *
+ * @param data - The raw JSON-parsed discovery response body.
+ * @param expectedIssuer - The issuer identifier the caller originally requested.
+ * @returns A validated {@link OidcDiscovery} object.
+ * @throws {OidcError} `DISCOVERY_INVALID` if required fields are missing or the response is not an object.
+ * @throws {OidcError} `DISCOVERY_ISSUER_MISMATCH` if the returned issuer does not match `expectedIssuer`.
+ *
+ * @see OpenID Connect Discovery 1.0 §4.3 -- OpenID Provider Configuration Response
+ */
 // OIDC Discovery §4.3: OpenID Provider Configuration Response
 export function parseDiscoveryResponse(data: unknown, expectedIssuer: string): OidcDiscovery {
   if (!data || typeof data !== "object") {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,3 +1,9 @@
+/**
+ * Union of all typed error codes thrown by oidc-js-core.
+ *
+ * Each code maps to a specific validation or protocol failure defined in
+ * RFC 6749, RFC 7636, or OpenID Connect Core 1.0.
+ */
 export type OidcErrorCode =
   | "DISCOVERY_INVALID"
   | "DISCOVERY_ISSUER_MISMATCH"
@@ -10,8 +16,14 @@ export type OidcErrorCode =
   | "MISSING_REDIRECT_URI"
   | "MISSING_CLIENT_SECRET";
 
+/**
+ * Structured error thrown by all oidc-js-core functions instead of generic `Error`.
+ *
+ * Consumers can switch on {@link OidcError.code} for programmatic error handling.
+ */
 export class OidcError extends Error {
   constructor(
+    /** Typed error code identifying the failure category. */
     public readonly code: OidcErrorCode,
     message: string,
   ) {

--- a/packages/core/src/introspect.ts
+++ b/packages/core/src/introspect.ts
@@ -2,6 +2,18 @@ import type { OidcConfig, OidcDiscovery, HttpRequest, IntrospectionResponse } fr
 import { OidcError } from "./errors.js";
 import { buildClientAuthHeaders } from "./auth.js";
 
+/**
+ * Builds an HTTP request for token introspection using HTTP Basic client authentication.
+ * Returns `null` if the discovery document has no `introspection_endpoint`.
+ *
+ * @param discovery - The OIDC discovery document.
+ * @param config - The OIDC client configuration (must include `clientSecret`).
+ * @param token - The token to introspect.
+ * @returns An {@link HttpRequest} for the introspection endpoint, or `null` if the endpoint is not available.
+ * @throws {@link OidcError} with code `MISSING_CLIENT_SECRET` if `clientSecret` is not configured.
+ *
+ * @see RFC 7662 §2.1 -- Introspection Request
+ */
 // RFC 7662 §2.1: Introspection Request
 export function buildIntrospectRequest(
   discovery: OidcDiscovery,
@@ -29,6 +41,15 @@ export function buildIntrospectRequest(
   };
 }
 
+/**
+ * Parses and validates a token introspection response, ensuring the required `active` field is present.
+ *
+ * @param data - The parsed JSON body returned from the introspection endpoint.
+ * @returns The validated {@link IntrospectionResponse}.
+ * @throws {@link OidcError} with code `TOKEN_EXCHANGE_ERROR` if the response is not an object or `active` is missing.
+ *
+ * @see RFC 7662 §2.2 -- Introspection Response
+ */
 // RFC 7662 §2.2: Introspection Response
 export function parseIntrospectResponse(data: unknown): IntrospectionResponse {
   if (!data || typeof data !== "object") {

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -1,6 +1,14 @@
 import type { OidcUser } from "./types.js";
 import { OidcError } from "./errors.js";
 
+/**
+ * Decodes the payload of a JWT without verifying its signature (RFC 7519 §7.2).
+ * Performs base64url decoding and JSON parsing only.
+ *
+ * @param token - A compact-serialized JWT string (header.payload.signature).
+ * @returns The decoded payload as a key-value record.
+ * @throws {@link OidcError} with code `INVALID_JWT` if the token does not have three parts or the payload cannot be decoded.
+ */
 export function decodeJwtPayload(token: string): Record<string, unknown> {
   const parts = token.split(".");
   if (parts.length !== 3) {
@@ -16,6 +24,13 @@ export function decodeJwtPayload(token: string): Record<string, unknown> {
   }
 }
 
+/**
+ * Extracts standard OIDC claims from an ID token by decoding its payload (OpenID Connect Core 1.0 §2).
+ * Does not verify the token signature.
+ *
+ * @param idToken - A compact-serialized ID token JWT.
+ * @returns The decoded claims as an {@link OidcUser}.
+ */
 // OIDC Core §2: ID token claims
 export function parseIdTokenClaims(idToken: string): OidcUser {
   const claims = decodeJwtPayload(idToken);

--- a/packages/core/src/logout.ts
+++ b/packages/core/src/logout.ts
@@ -1,5 +1,16 @@
 import type { OidcDiscovery } from "./types.js";
 
+/**
+ * Builds an RP-Initiated Logout URL for ending the user's session at the OpenID Provider.
+ * Returns `null` if the discovery document has no `end_session_endpoint`.
+ *
+ * @param discovery - The OIDC discovery document.
+ * @param idToken - Optional ID token to pass as `id_token_hint` so the OP can identify the session.
+ * @param postLogoutRedirectUri - Optional URI to redirect the user to after logout completes.
+ * @returns The fully constructed logout URL, or `null` if the endpoint is not available.
+ *
+ * @see OpenID Connect RP-Initiated Logout 1.0 §2 -- Logout Request
+ */
 // OIDC RP-Initiated Logout §2: Logout Request
 export function buildLogoutUrl(
   discovery: OidcDiscovery,

--- a/packages/core/src/revocation.ts
+++ b/packages/core/src/revocation.ts
@@ -1,6 +1,18 @@
 import type { OidcConfig, OidcDiscovery, HttpRequest } from "./types.js";
 import { buildClientAuthHeaders } from "./auth.js";
 
+/**
+ * Builds an HTTP request to revoke an OAuth 2.0 token.
+ * Returns `null` if the discovery document has no `revocation_endpoint`.
+ *
+ * @param discovery - The OIDC discovery document.
+ * @param config - The OIDC client configuration.
+ * @param token - The token to revoke (access or refresh token).
+ * @param tokenTypeHint - Optional hint indicating whether the token is an `access_token` or `refresh_token`.
+ * @returns An {@link HttpRequest} for the revocation endpoint, or `null` if the endpoint is not available.
+ *
+ * @see RFC 7009 §2.1 -- Token Revocation Request
+ */
 // RFC 7009 §2.1: Token Revocation Request
 export function buildRevocationRequest(
   discovery: OidcDiscovery,

--- a/packages/core/src/token-utils.ts
+++ b/packages/core/src/token-utils.ts
@@ -1,9 +1,23 @@
 import type { TokenSet } from "./types.js";
 
+/**
+ * Converts a relative `expires_in` value (seconds from now) to an absolute Unix timestamp.
+ *
+ * @param expiresIn - Token lifetime in seconds, as returned by the token endpoint (RFC 6749 §5.1).
+ * @returns Absolute expiry time as a Unix timestamp in seconds.
+ */
 export function computeExpiresAt(expiresIn: number): number {
   return Math.floor(Date.now() / 1000) + expiresIn;
 }
 
+/**
+ * Checks whether the access token in a {@link TokenSet} has expired.
+ * Returns `false` if no `expires_at` is set (the token is treated as non-expiring).
+ *
+ * @param tokenSet - The token set to check.
+ * @param clockSkewSeconds - Optional allowance for clock drift between client and server (defaults to 0).
+ * @returns `true` if the current time is at or past the adjusted expiry time.
+ */
 export function isTokenExpired(tokenSet: TokenSet, clockSkewSeconds: number = 0): boolean {
   if (tokenSet.expires_at === undefined) {
     return false;
@@ -11,6 +25,13 @@ export function isTokenExpired(tokenSet: TokenSet, clockSkewSeconds: number = 0)
   return Math.floor(Date.now() / 1000) >= tokenSet.expires_at - clockSkewSeconds;
 }
 
+/**
+ * Returns the number of seconds remaining until the token expires.
+ * Returns `Infinity` if no `expires_at` is set, or `0` if the token is already expired.
+ *
+ * @param tokenSet - The token set to inspect.
+ * @returns Seconds remaining until expiry (never negative).
+ */
 export function timeUntilExpiry(tokenSet: TokenSet): number {
   if (tokenSet.expires_at === undefined) {
     return Infinity;

--- a/packages/core/src/token.ts
+++ b/packages/core/src/token.ts
@@ -3,6 +3,15 @@ import { OidcError } from "./errors.js";
 import { decodeJwtPayload } from "./jwt.js";
 import { buildClientAuthHeaders } from "./auth.js";
 
+/**
+ * Builds an HTTP request to exchange an authorization code for tokens (RFC 6749 §4.1.3).
+ *
+ * @param discovery - The OIDC discovery document containing the token endpoint.
+ * @param config - Client configuration (clientId, redirectUri, optional clientSecret).
+ * @param code - The authorization code received from the authorization endpoint.
+ * @param codeVerifier - The PKCE code verifier that matches the code_challenge sent earlier (RFC 7636 §4.5).
+ * @returns An {@link HttpRequest} ready to be sent to the token endpoint.
+ */
 // RFC 6749 §4.1.3: Access Token Request
 // RFC 7636 §4.5: code_verifier MUST be sent when code_challenge was used
 export function buildTokenRequest(
@@ -34,6 +43,14 @@ export function buildTokenRequest(
   };
 }
 
+/**
+ * Builds an HTTP request to refresh an access token using a refresh token (RFC 6749 §6).
+ *
+ * @param discovery - The OIDC discovery document containing the token endpoint.
+ * @param config - Client configuration (clientId, optional clientSecret).
+ * @param refreshToken - The refresh token previously issued by the authorization server.
+ * @returns An {@link HttpRequest} ready to be sent to the token endpoint.
+ */
 // RFC 6749 §6: Refreshing an Access Token
 export function buildRefreshRequest(
   discovery: OidcDiscovery,
@@ -57,6 +74,17 @@ export function buildRefreshRequest(
   };
 }
 
+/**
+ * Parses and validates a raw token endpoint response into a {@link TokenSet} (RFC 6749 §5.1).
+ * Validates the nonce claim in the ID token when provided (OpenID Connect Core 1.0 §3.1.3.7).
+ * Computes `expires_at` as an absolute Unix timestamp when `expires_in` is present.
+ *
+ * @param data - The parsed JSON body from the token endpoint response.
+ * @param expectedNonce - If provided, the nonce claim in the ID token must match this value.
+ * @returns A validated {@link TokenSet} with computed `expires_at`.
+ * @throws {@link OidcError} with code `TOKEN_EXCHANGE_ERROR` if the response is malformed or missing `access_token`.
+ * @throws {@link OidcError} with code `NONCE_MISMATCH` if the ID token nonce does not match.
+ */
 // RFC 6749 §5.1: Successful Response
 // OIDC Core §3.1.3.7: nonce in ID token MUST match the nonce sent in the authorization request
 export function parseTokenResponse(data: unknown, expectedNonce?: string): TokenSet {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,77 +1,170 @@
+/**
+ * Client configuration for an OIDC/OAuth 2.0 provider.
+ *
+ * Supports both public clients (no `clientSecret`) and confidential clients.
+ * See RFC 6749 Section 2.1 for client type definitions.
+ */
 export interface OidcConfig {
+  /** Issuer identifier URL (must match the discovery document's `issuer` field). */
   issuer: string;
+  /** OAuth 2.0 client identifier issued during registration (RFC 6749 Section 2.2). */
   clientId: string;
+  /** Client secret for confidential clients (RFC 6749 Section 2.3.1). Omit for public clients. */
   clientSecret?: string;
+  /** Redirection URI for authorization code responses (RFC 6749 Section 3.1.2). */
   redirectUri?: string;
+  /** OAuth 2.0 scopes to request. Defaults to `["openid"]` if omitted. */
   scopes?: string[];
+  /** URI to redirect to after logout (OpenID Connect RP-Initiated Logout 1.0). */
   postLogoutRedirectUri?: string;
 }
 
+/**
+ * OpenID Provider discovery metadata as defined in OpenID Connect Discovery 1.0 Section 3.
+ *
+ * Required and optional fields mirror the provider's `/.well-known/openid-configuration` response.
+ */
 export interface OidcDiscovery {
+  /** Issuer identifier (must exactly match the `issuer` in {@link OidcConfig}). */
   issuer: string;
+  /** URL of the authorization endpoint (RFC 6749 Section 3.1). */
   authorization_endpoint: string;
+  /** URL of the token endpoint (RFC 6749 Section 3.2). */
   token_endpoint: string;
+  /** URL of the UserInfo endpoint (OpenID Connect Core 1.0 Section 5.3). */
   userinfo_endpoint: string;
+  /** URL of the provider's JSON Web Key Set document (RFC 7517). */
   jwks_uri: string;
+  /** URL of the end-session endpoint (OpenID Connect RP-Initiated Logout 1.0). */
   end_session_endpoint?: string;
+  /** URL of the token revocation endpoint (RFC 7009). */
   revocation_endpoint?: string;
+  /** URL of the token introspection endpoint (RFC 7662). */
   introspection_endpoint?: string;
+  /** Response types the provider supports (OpenID Connect Discovery 1.0 Section 3). */
   response_types_supported: string[];
+  /** Subject identifier types the provider supports (`public`, `pairwise`). */
   subject_types_supported: string[];
+  /** JWS signing algorithms supported for ID tokens (RFC 7518). */
   id_token_signing_alg_values_supported: string[];
+  /** Scopes the provider supports. */
   scopes_supported?: string[];
+  /** Client authentication methods supported at the token endpoint. */
   token_endpoint_auth_methods_supported?: string[];
+  /** PKCE code challenge methods supported (RFC 7636 Section 4.3). */
   code_challenge_methods_supported?: string[];
+  /** Grant types the provider supports (RFC 6749 Section 1.3). */
   grant_types_supported?: string[];
+  /** Claims the provider can supply. */
   claims_supported?: string[];
+  /** Prompt values the provider supports (OpenID Connect Core 1.0 Section 3.1.2.1). */
   prompt_values_supported?: string[];
 }
 
+/**
+ * Raw token endpoint response as defined in RFC 6749 Section 5.1.
+ */
 export interface TokenResponse {
+  /** The access token issued by the authorization server. */
   access_token: string;
+  /** Token type (typically `"Bearer"`, per RFC 6750). */
   token_type: string;
+  /** Lifetime of the access token in seconds. */
   expires_in?: number;
+  /** Refresh token for obtaining new access tokens (RFC 6749 Section 1.5). */
   refresh_token?: string;
+  /** ID token containing user claims (OpenID Connect Core 1.0 Section 2). */
   id_token?: string;
+  /** Space-delimited list of granted scopes. */
   scope?: string;
 }
 
+/**
+ * Extended token response that includes a computed absolute expiration timestamp.
+ *
+ * Produced by {@link parseTokenResponse} from a raw {@link TokenResponse}.
+ */
 export interface TokenSet extends TokenResponse {
+  /** Absolute expiration time as a Unix timestamp in milliseconds, computed from `expires_in`. */
   expires_at?: number;
 }
 
+/**
+ * State stored before redirecting to the authorization endpoint.
+ *
+ * Used to validate the callback and complete the token exchange.
+ */
 export interface AuthState {
+  /** PKCE code verifier (RFC 7636 Section 4.1). */
   codeVerifier: string;
+  /** Anti-CSRF state parameter (RFC 6749 Section 10.12). */
   state: string;
+  /** Nonce binding the ID token to this session (OpenID Connect Core 1.0 Section 3.1.2.1). */
   nonce: string;
+  /** Redirect URI used for this authorization request. */
   redirectUri: string;
+  /** Application route to restore after login completes. */
   returnTo?: string;
 }
 
+/**
+ * Decoded user claims from the UserInfo endpoint or an ID token.
+ *
+ * Standard claims follow OpenID Connect Core 1.0 Section 5.1. Additional
+ * provider-specific claims are accessible via the index signature.
+ */
 export interface OidcUser {
+  /** Subject identifier -- unique, stable user ID (OpenID Connect Core 1.0 Section 2). */
   sub: string;
+  /** User's email address. */
   email?: string;
+  /** User's full display name. */
   name?: string;
+  /** User's preferred short-form username. */
   preferred_username?: string;
+  /** Additional claims not covered by the named fields. */
   [claim: string]: unknown;
 }
 
+/**
+ * A prepared HTTP request ready to be executed by the caller's HTTP layer.
+ *
+ * Core functions return this instead of calling `fetch` directly, preserving the
+ * "functional core, imperative shell" architecture.
+ */
 export interface HttpRequest {
+  /** Fully qualified request URL. */
   url: string;
+  /** HTTP method (e.g., `"POST"`, `"GET"`). */
   method: string;
+  /** HTTP headers to include with the request. */
   headers: Record<string, string>;
+  /** Request body, typically `application/x-www-form-urlencoded` for token requests. */
   body?: string;
 }
 
+/**
+ * Token introspection response as defined in RFC 7662 Section 2.2.
+ */
 export interface IntrospectionResponse {
+  /** Whether the token is currently active. */
   active: boolean;
+  /** Space-delimited scopes associated with the token. */
   scope?: string;
+  /** Client identifier for the token. */
   client_id?: string;
+  /** Human-readable identifier for the resource owner. */
   username?: string;
+  /** Token type (e.g., `"Bearer"`). */
   token_type?: string;
+  /** Expiration time as a Unix timestamp in seconds (RFC 7662 Section 2.2). */
   exp?: number;
+  /** Issued-at time as a Unix timestamp in seconds. */
   iat?: number;
+  /** Subject of the token. */
   sub?: string;
+  /** Audience the token is intended for. */
   aud?: string;
+  /** Issuer of the token. */
   iss?: string;
 }

--- a/packages/core/src/userinfo.ts
+++ b/packages/core/src/userinfo.ts
@@ -1,6 +1,16 @@
 import type { OidcDiscovery, HttpRequest, OidcUser } from "./types.js";
 import { OidcError } from "./errors.js";
 
+/**
+ * Builds an HTTP request to the UserInfo endpoint using a Bearer access token.
+ *
+ * @param discovery - The OIDC discovery document containing the `userinfo_endpoint`.
+ * @param accessToken - A valid access token issued by the authorization server.
+ * @returns An {@link HttpRequest} configured with the Bearer Authorization header.
+ *
+ * @see OpenID Connect Core 1.0 §5.3.1 -- UserInfo Request
+ * @see RFC 6750 §2.1 -- Bearer token in Authorization header
+ */
 // OIDC Core §5.3.1: UserInfo Request
 // RFC 6750 §2.1: Bearer token in Authorization header
 export function buildUserinfoRequest(discovery: OidcDiscovery, accessToken: string): HttpRequest {
@@ -13,6 +23,15 @@ export function buildUserinfoRequest(discovery: OidcDiscovery, accessToken: stri
   };
 }
 
+/**
+ * Parses and validates a UserInfo response, ensuring the required `sub` claim is present.
+ *
+ * @param data - The parsed JSON body returned from the UserInfo endpoint.
+ * @returns The validated {@link OidcUser} object.
+ * @throws {@link OidcError} with code `TOKEN_EXCHANGE_ERROR` if the response is not an object or `sub` is missing.
+ *
+ * @see OpenID Connect Core 1.0 §5.3.2 -- UserInfo Response
+ */
 // OIDC Core §5.3.2: UserInfo Response
 export function parseUserinfoResponse(data: unknown): OidcUser {
   if (!data || typeof data !== "object") {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,19 +25,28 @@ importers:
         version: 3.7.2
       '@astrojs/starlight':
         specifier: ^0.37.6
-        version: 0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3))
+        version: 0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
       '@pasqal-io/starlight-client-mermaid':
         specifier: ^0.1.0
-        version: 0.1.0(@astrojs/markdown-remark@6.3.11)(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)))
+        version: 0.1.0(@astrojs/markdown-remark@6.3.11)(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)))
       astro:
         specifier: ^5.6.1
-        version: 5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)
+        version: 5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
       sharp:
         specifier: ^0.34.2
         version: 0.34.5
       starlight-theme-galaxy:
         specifier: ^0.7.0
-        version: 0.7.0(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)))
+        version: 0.7.0(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)))
+      starlight-typedoc:
+        specifier: ^0.21.5
+        version: 0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3))
+      typedoc:
+        specifier: ^0.28.19
+        version: 0.28.19(typescript@5.9.3)
+      typedoc-plugin-markdown:
+        specifier: ^4.11.0
+        version: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
 
   packages/angular: {}
 
@@ -52,13 +61,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: ^4.0.0
-        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
       vitest:
         specifier: ^4.0.0
-        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
+        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
 
   packages/core:
     devDependencies:
@@ -67,13 +76,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: ^4.0.0
-        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
       vitest:
         specifier: ^4.0.0
-        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
+        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
 
   packages/react:
     dependencies:
@@ -101,13 +110,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: ^4.0.0
-        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
       vitest:
         specifier: ^4.0.0
-        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
+        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
 
   packages/solid: {}
 
@@ -150,13 +159,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
-        version: 4.7.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
+        version: 4.7.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
       vite:
         specifier: ^8.0.0
-        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
 
 packages:
 
@@ -718,6 +727,9 @@ packages:
 
   '@fontsource-variable/jetbrains-mono@5.2.8':
     resolution: {integrity: sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==}
+
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -2729,6 +2741,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
@@ -2753,6 +2768,9 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -2766,6 +2784,10 @@ packages:
   markdown-extensions@2.0.0:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -2834,6 +2856,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
@@ -3149,6 +3174,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3381,6 +3410,14 @@ packages:
     peerDependencies:
       '@astrojs/starlight': '>=0.34'
 
+  starlight-typedoc@0.21.5:
+    resolution: {integrity: sha512-7JGaPHrP+HgX0sYGnafZcPuzMm+3OmHx7kqE0DWTrsuBfoQS02lJ6/PtJF9y0KCDcfsBynyo0G/1ttHcBq5Vww==}
+    engines: {node: '>=18.17.1'}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.32.0'
+      typedoc: '>=0.28.0'
+      typedoc-plugin-markdown: '>=4.6.0'
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
@@ -3505,6 +3542,19 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  typedoc-plugin-markdown@4.11.0:
+    resolution: {integrity: sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      typedoc: 0.28.x
+
+  typedoc@0.28.19:
+    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+
   typescript-eslint@8.59.1:
     resolution: {integrity: sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3516,6 +3566,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -3895,6 +3948,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -3980,12 +4038,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3))':
+  '@astrojs/mdx@4.3.14(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.11
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)
+      astro: 5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -4009,17 +4067,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.1
 
-  '@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3))':
+  '@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.11
-      '@astrojs/mdx': 4.3.14(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3))
+      '@astrojs/mdx': 4.3.14(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)
-      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3))
+      astro: 5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
+      astro-expressive-code: 0.41.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -4451,6 +4509,14 @@ snapshots:
 
   '@fontsource-variable/jetbrains-mono@5.2.8': {}
 
+  '@gerrit0/mini-shiki@3.23.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -4693,10 +4759,10 @@ snapshots:
   '@pagefind/windows-x64@1.5.2':
     optional: true
 
-  '@pasqal-io/starlight-client-mermaid@0.1.0(@astrojs/markdown-remark@6.3.11)(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)))':
+  '@pasqal-io/starlight-client-mermaid@0.1.0(@astrojs/markdown-remark@6.3.11)(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.11
-      '@astrojs/starlight': 0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3))
+      '@astrojs/starlight': 0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
       mermaid: 11.14.0
       unist-util-visit: 5.1.0
 
@@ -5248,7 +5314,7 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  '@vitejs/plugin-react@4.7.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))':
+  '@vitejs/plugin-react@4.7.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5256,7 +5322,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5269,13 +5335,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -5415,12 +5481,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)):
+  astro-expressive-code@0.41.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      astro: 5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)
+      astro: 5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)
       rehype-expressive-code: 0.41.7
 
-  astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3):
+  astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 2.13.1
       '@astrojs/internal-helpers': 0.7.6
@@ -5477,8 +5543,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)
-      vitefu: 1.1.3(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0))
+      vite: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(yaml@2.8.3))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -6660,6 +6726,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   local-pkg@1.1.2:
     dependencies:
       mlly: 1.8.2
@@ -6682,6 +6752,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lunr@2.3.9: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -6695,6 +6767,15 @@ snapshots:
       source-map-js: 1.2.1
 
   markdown-extensions@2.0.0: {}
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -6886,6 +6967,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
+
+  mdurl@2.0.0: {}
 
   mermaid@11.14.0:
     dependencies:
@@ -7395,6 +7478,8 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
@@ -7748,13 +7833,20 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-theme-galaxy@0.7.0(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3))):
+  starlight-theme-galaxy@0.7.0(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))):
     dependencies:
-      '@astrojs/starlight': 0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3))
+      '@astrojs/starlight': 0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
       '@expressive-code/core': 0.41.7
       '@expressive-code/plugin-line-numbers': 0.41.7
       '@fontsource-variable/inter': 5.2.8
       '@fontsource-variable/jetbrains-mono': 5.2.8
+
+  starlight-typedoc@0.21.5(@astrojs/starlight@0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3)))(typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)))(typedoc@0.28.19(typescript@5.9.3)):
+    dependencies:
+      '@astrojs/starlight': 0.37.7(astro@5.18.1(@types/node@25.6.0)(lightningcss@1.32.0)(rollup@4.60.2)(typescript@5.9.3)(yaml@2.8.3))
+      github-slugger: 2.0.0
+      typedoc: 0.28.19(typescript@5.9.3)
+      typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
 
   std-env@4.1.0: {}
 
@@ -7865,6 +7957,19 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)):
+    dependencies:
+      typedoc: 0.28.19(typescript@5.9.3)
+
+  typedoc@0.28.19(typescript@5.9.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
+      lunr: 2.3.9
+      markdown-it: 14.1.1
+      minimatch: 10.2.5
+      typescript: 5.9.3
+      yaml: 2.8.3
+
   typescript-eslint@8.59.1(eslint@10.2.1)(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.59.1(@typescript-eslint/parser@8.59.1(eslint@10.2.1)(typescript@5.9.3))(eslint@10.2.1)(typescript@5.9.3)
@@ -7877,6 +7982,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
 
@@ -7992,7 +8099,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-dts@4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)):
+  vite-plugin-dts@4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)):
     dependencies:
       '@microsoft/api-extractor': 7.58.7(@types/node@25.6.0)
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
@@ -8005,13 +8112,13 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0):
+  vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8023,8 +8130,9 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       lightningcss: 1.32.0
+      yaml: 2.8.3
 
-  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7):
+  vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8035,15 +8143,16 @@ snapshots:
       '@types/node': 25.6.0
       esbuild: 0.27.7
       fsevents: 2.3.3
+      yaml: 2.8.3
 
-  vitefu@1.1.3(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)):
+  vitefu@1.1.3(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(yaml@2.8.3)):
     optionalDependencies:
-      vite: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(yaml@2.8.3)
 
-  vitest@4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)):
+  vitest@4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -8060,7 +8169,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -8136,6 +8245,8 @@ snapshots:
   xxhash-wasm@1.1.0: {}
 
   yallist@3.1.1: {}
+
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary
- Add TSDoc comments with RFC references to all exported functions, classes, interfaces, and types in `oidc-js-core` and `oidc-js` (client) packages
- Integrate `starlight-typedoc` to auto-generate API reference pages from TSDoc at build time
- Separate TypeDoc instances for core and client packages (each with its own tsconfig)
- Generated API docs are gitignored (regenerated on every build)
- Docs site now builds 104 pages: 19 hand-written + 85 auto-generated API reference

## Files changed
- `packages/core/src/*.ts` -- TSDoc on all 13 source files
- `packages/client/src/*.ts` -- TSDoc on all 4 source files
- `docs-web/astro.config.mjs` -- starlight-typedoc plugin config
- `docs-web/package.json` -- added starlight-typedoc, typedoc, typedoc-plugin-markdown
- `docs-web/.gitignore` -- ignore generated api/ directory

## Test plan
- [x] `pnpm --filter oidc-js-core test` passes (95/95)
- [x] `pnpm --filter oidc-js-docs build` succeeds (104 pages)
- [x] No em dashes in new TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)