### PR TITLE
fix: use dedicated tsconfig for client TypeDoc generation

### DIFF
--- a/docs-web/astro.config.mjs
+++ b/docs-web/astro.config.mjs
@@ -42,7 +42,7 @@ export default defineConfig({
 				}),
 				starlightTypeDoc({
 					entryPoints: ['../packages/client/src/index.ts'],
-					tsconfig: '../packages/client/tsconfig.json',
+					tsconfig: '../packages/client/tsconfig.typedoc.json',
 					output: 'api/client',
 					sidebar: {
 						label: 'API Reference (Client)',

--- a/packages/client/tsconfig.typedoc.json
+++ b/packages/client/tsconfig.typedoc.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "lib": ["ES2022", "DOM"],
+    "paths": {
+      "oidc-js-core": ["../core/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["src/tests"]
+}


### PR DESCRIPTION
## Summary
- Fix CI docs build failure: TypeDoc couldn't resolve `oidc-js-core` workspace imports from the client package
- Add `packages/client/tsconfig.typedoc.json` with `paths` mapping to core source and no `rootDir` constraint
- Point the client TypeDoc plugin instance to the new tsconfig

## Test plan
- [x] `pnpm --filter oidc-js-docs build` succeeds (104 pages, no errors)
- [x] `pnpm build` still passes for all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)