### PR TITLE
feat: add Vue adapter package and E2E test app

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,8 +1,47 @@
 {
   "name": "oidc-js-vue",
   "version": "0.0.1",
-  "description": "Vue bindings for oidc-js (coming soon)",
-  "license": "MIT",
+  "description": "Vue bindings for oidc-js",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": [
+    "oidc",
+    "openid",
+    "oauth2",
+    "vue",
+    "authentication"
+  ],
   "author": "eugenioenko",
-  "keywords": ["oidc", "openid", "oauth2", "vue", "authentication"]
+  "license": "MIT",
+  "dependencies": {
+    "oidc-js": "workspace:*",
+    "oidc-js-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "vue": ">=3.3.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vite": "^8.0.0",
+    "vite-plugin-dts": "^4.0.0",
+    "vitest": "^4.0.0",
+    "vue": "^3.5.0"
+  }
 }

--- a/packages/vue/src/auth-required.ts
+++ b/packages/vue/src/auth-required.ts
@@ -1,0 +1,83 @@
+import { defineComponent, h, ref, watch, type PropType, type VNode } from "vue";
+import { useAuth } from "./composable.js";
+import type { LoginOptions } from "oidc-js";
+
+/**
+ * Renderless component that guards its slot content behind authentication.
+ *
+ * Renders the default slot only when the user is authenticated and the token is not expired.
+ * While loading or when authentication is required, renders the `fallback` slot instead.
+ *
+ * If the token is expired and `autoRefresh` is enabled (default), it attempts a token refresh.
+ * If the refresh fails, it redirects the user to the OIDC login flow.
+ *
+ * @example
+ * ```vue
+ * <template>
+ *   <RequireAuth>
+ *     <template #fallback>
+ *       <div>Loading...</div>
+ *     </template>
+ *     <div>Protected content</div>
+ *   </RequireAuth>
+ * </template>
+ * ```
+ */
+export const RequireAuth = defineComponent({
+  name: "RequireAuth",
+  props: {
+    /** Whether to automatically attempt a token refresh when the token is expired. Defaults to true. */
+    autoRefresh: {
+      type: Boolean,
+      default: true,
+    },
+    /** Options to pass to the login method when redirecting unauthenticated users. */
+    loginOptions: {
+      type: Object as PropType<LoginOptions>,
+      default: undefined,
+    },
+  },
+  setup(props, { slots }) {
+    const { isAuthenticated, isLoading, tokens, actions } = useAuth();
+    const refreshAttempted = ref(false);
+
+    watch(
+      [isAuthenticated, isLoading, tokens],
+      () => {
+        const isExpired =
+          tokens.value.expiresAt !== null &&
+          tokens.value.expiresAt <= Date.now();
+        const needsAuth = !isAuthenticated.value || isExpired;
+
+        if (!needsAuth) {
+          refreshAttempted.value = false;
+          return;
+        }
+
+        if (isLoading.value) return;
+
+        if (props.autoRefresh && !refreshAttempted.value) {
+          refreshAttempted.value = true;
+          actions.refresh().catch(() => actions.login(props.loginOptions));
+          return;
+        }
+
+        actions.login(props.loginOptions);
+      },
+      { immediate: true },
+    );
+
+    return (): VNode | VNode[] | null => {
+      const isExpired =
+        tokens.value.expiresAt !== null &&
+        tokens.value.expiresAt <= Date.now();
+      const needsAuth = !isAuthenticated.value || isExpired;
+
+      if (isLoading.value || needsAuth) {
+        return slots.fallback?.() ?? null;
+      }
+
+      return slots.default?.() ?? null;
+    };
+  },
+});

--- a/packages/vue/src/composable.ts
+++ b/packages/vue/src/composable.ts
@@ -1,0 +1,73 @@
+import { inject, computed, type ComputedRef } from "vue";
+import { AUTH_CONTEXT_KEY } from "./plugin.js";
+import type { AuthActions, AuthContextValue } from "./types.js";
+
+/**
+ * Return type of the {@link useAuth} composable.
+ *
+ * Provides computed refs for reactive auth state and an actions object
+ * for triggering authentication operations.
+ */
+export interface UseAuthReturn {
+  /** The authenticated user, or null if not logged in. */
+  user: ComputedRef<AuthContextValue["user"]>;
+  /** Whether the user is currently authenticated. */
+  isAuthenticated: ComputedRef<boolean>;
+  /** Whether initialization or a token exchange is in progress. */
+  isLoading: ComputedRef<boolean>;
+  /** The most recent authentication error, or null if none. */
+  error: ComputedRef<Error | null>;
+  /** Current set of OAuth 2.0 tokens. */
+  tokens: ComputedRef<AuthContextValue["tokens"]>;
+  /** Actions for login, logout, refresh, and profile fetching. */
+  actions: AuthActions;
+  /** The OIDC configuration used to initialize the client. */
+  config: AuthContextValue["config"];
+}
+
+/**
+ * Vue composable that provides access to the OIDC authentication state and actions.
+ *
+ * Must be called within a component tree where the {@link oidcPlugin} has been installed.
+ * Returns computed refs for reactive state tracking and an actions object for
+ * triggering login, logout, refresh, and profile fetching.
+ *
+ * @returns The authentication state as computed refs and action methods.
+ * @throws Error if called outside of a component tree with the OIDC plugin installed.
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { useAuth } from "oidc-js-vue";
+ *
+ * const { user, isAuthenticated, isLoading, actions } = useAuth();
+ * </script>
+ *
+ * <template>
+ *   <div v-if="isLoading">Loading...</div>
+ *   <div v-else-if="isAuthenticated">
+ *     <p>Welcome, {{ user?.claims.sub }}</p>
+ *     <button @click="actions.logout()">Logout</button>
+ *   </div>
+ *   <div v-else>
+ *     <button @click="actions.login()">Login</button>
+ *   </div>
+ * </template>
+ * ```
+ */
+export function useAuth(): UseAuthReturn {
+  const context = inject(AUTH_CONTEXT_KEY);
+  if (!context) {
+    throw new Error("useAuth must be used within a component tree where oidcPlugin is installed");
+  }
+
+  return {
+    user: computed(() => context.user.value),
+    isAuthenticated: computed(() => context.isAuthenticated.value),
+    isLoading: computed(() => context.isLoading.value),
+    error: computed(() => context.error.value),
+    tokens: computed(() => context.tokens.value),
+    actions: context.actions,
+    config: context.config,
+  };
+}

--- a/packages/vue/src/guard.ts
+++ b/packages/vue/src/guard.ts
@@ -1,0 +1,90 @@
+import { inject } from "vue";
+import { AUTH_CONTEXT_KEY } from "./plugin.js";
+import type { LoginOptions } from "oidc-js";
+
+/**
+ * Options for the {@link createAuthGuard} navigation guard.
+ */
+export interface AuthGuardOptions {
+  /** Options to pass to the login method when redirecting unauthenticated users. */
+  loginOptions?: LoginOptions;
+}
+
+/**
+ * Creates a Vue Router navigation guard that protects routes requiring authentication.
+ *
+ * When a user navigates to a guarded route, the guard checks authentication status.
+ * If the token is expired, it attempts a refresh. If refresh fails or no refresh token
+ * is available, it redirects the user to the OIDC login flow, preserving the original
+ * destination as the `returnTo` path.
+ *
+ * This function must be called inside a component's `setup()` function or `<script setup>`,
+ * as it uses `inject()` to access the auth context provided by the {@link oidcPlugin}.
+ *
+ * @param router - The Vue Router instance to attach the guard to.
+ * @param options - Optional configuration for the guard behavior.
+ *
+ * @example
+ * ```vue
+ * <script setup lang="ts">
+ * import { useRouter } from "vue-router";
+ * import { createAuthGuard } from "oidc-js-vue";
+ *
+ * const router = useRouter();
+ * createAuthGuard(router);
+ * </script>
+ * ```
+ */
+export function createAuthGuard(
+  router: { beforeEach: (guard: (to: { fullPath: string }, from: unknown, next: (location?: string | false) => void) => void) => void },
+  options?: AuthGuardOptions,
+): void {
+  const context = inject(AUTH_CONTEXT_KEY);
+  if (!context) {
+    throw new Error("createAuthGuard must be used within a component tree where oidcPlugin is installed");
+  }
+
+  router.beforeEach(async (to, _from, next) => {
+    // If still loading, wait for initialization to complete
+    if (context.isLoading.value) {
+      await new Promise<void>((resolve) => {
+        const check = () => {
+          if (!context.isLoading.value) {
+            resolve();
+          } else {
+            setTimeout(check, 10);
+          }
+        };
+        check();
+      });
+    }
+
+    const isExpired =
+      context.tokens.value.expiresAt !== null &&
+      context.tokens.value.expiresAt <= Date.now();
+
+    if (context.isAuthenticated.value && !isExpired) {
+      next();
+      return;
+    }
+
+    // If we have a refresh token, try refreshing
+    if (context.tokens.value.refresh) {
+      try {
+        await context.actions.refresh();
+        next();
+        return;
+      } catch {
+        // Refresh failed, fall through to login
+      }
+    }
+
+    // Redirect to login with returnTo
+    await context.actions.login({
+      returnTo: to.fullPath,
+      ...options?.loginOptions,
+    });
+
+    next(false);
+  });
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,19 @@
+export { oidcPlugin } from "./plugin.js";
+export { useAuth } from "./composable.js";
+export { RequireAuth } from "./auth-required.js";
+export { createAuthGuard } from "./guard.js";
+
+export type { UseAuthReturn } from "./composable.js";
+export type { AuthGuardOptions } from "./guard.js";
+
+export type {
+  IdTokenClaims,
+  AuthUser,
+  AuthTokens,
+  AuthActions,
+  AuthContextValue,
+  LoginOptions,
+  OidcPluginOptions,
+} from "./types.js";
+
+export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -1,0 +1,126 @@
+import { ref, type App, type InjectionKey, type Ref } from "vue";
+import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
+import type { OidcConfig } from "oidc-js-core";
+import type { AuthActions, AuthContextValue, OidcPluginOptions } from "./types.js";
+
+/**
+ * Vue injection key for the authentication context.
+ *
+ * Used internally by the {@link oidcPlugin} and {@link useAuth} composable
+ * to provide and inject the reactive auth state.
+ */
+export const AUTH_CONTEXT_KEY: InjectionKey<{
+  config: OidcConfig;
+  user: Ref<AuthContextValue["user"]>;
+  isAuthenticated: Ref<boolean>;
+  isLoading: Ref<boolean>;
+  error: Ref<Error | null>;
+  tokens: Ref<AuthContextValue["tokens"]>;
+  actions: AuthActions;
+}> = Symbol("oidc-auth");
+
+/**
+ * Vue plugin that initializes the OIDC client and provides reactive auth state.
+ *
+ * Install via `app.use(oidcPlugin, options)`. Creates an {@link OidcClient},
+ * calls `init()`, subscribes to state changes, and stores state in Vue reactive
+ * refs via `app.provide()`. The client is destroyed when the app unmounts.
+ *
+ * @example
+ * ```ts
+ * import { createApp } from "vue";
+ * import { oidcPlugin } from "oidc-js-vue";
+ *
+ * const app = createApp(App);
+ * app.use(oidcPlugin, {
+ *   config: {
+ *     issuer: "https://accounts.example.com",
+ *     clientId: "my-app",
+ *     redirectUri: "http://localhost:3000/callback",
+ *     scopes: ["openid", "profile", "email"],
+ *   },
+ * });
+ * app.mount("#app");
+ * ```
+ *
+ * @param app - The Vue application instance.
+ * @param options - Plugin options including OIDC config and optional callbacks.
+ */
+export const oidcPlugin = {
+  install(app: App, options: OidcPluginOptions): void {
+    const { config, fetchProfile = true, onLogin, onError } = options;
+
+    const client = new OidcClient({ ...config, fetchProfile });
+
+    const user = ref<AuthContextValue["user"]>(null);
+    const isAuthenticated = ref(false);
+    const isLoading = ref(true);
+    const error = ref<Error | null>(null);
+    const tokens = ref<AuthContextValue["tokens"]>({
+      access: null,
+      id: null,
+      refresh: null,
+      expiresAt: null,
+    });
+
+    const unsub = client.subscribe((state: AuthState) => {
+      user.value = state.user;
+      isAuthenticated.value = state.isAuthenticated;
+      isLoading.value = state.isLoading;
+      error.value = state.error;
+      tokens.value = state.tokens;
+    });
+
+    client.init().then(({ returnTo }) => {
+      const s = client.state;
+      if (s.error) onError?.(s.error);
+      if (returnTo) {
+        if (onLogin) {
+          onLogin(returnTo);
+        } else {
+          window.history.replaceState({}, "", returnTo);
+        }
+      }
+    });
+
+    const login = async (loginOptions?: LoginOptions) => {
+      await client.login(loginOptions);
+    };
+
+    const logout = () => {
+      client.logout();
+    };
+
+    const refresh = async () => {
+      await client.refresh();
+    };
+
+    const doFetchProfile = async () => {
+      await client.fetchProfile();
+    };
+
+    const actions: AuthActions = {
+      login,
+      logout,
+      refresh,
+      fetchProfile: doFetchProfile,
+    };
+
+    app.provide(AUTH_CONTEXT_KEY, {
+      config,
+      user,
+      isAuthenticated,
+      isLoading,
+      error,
+      tokens,
+      actions,
+    });
+
+    const originalUnmount = app.unmount.bind(app);
+    app.unmount = () => {
+      unsub();
+      client.destroy();
+      originalUnmount();
+    };
+  },
+};

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,0 +1,61 @@
+import type { OidcConfig } from "oidc-js-core";
+
+export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+
+import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+
+/**
+ * Actions available for authentication operations.
+ *
+ * Returned by {@link useAuth} to allow components to trigger login, logout,
+ * token refresh, and profile fetching.
+ */
+export interface AuthActions {
+  /** Initiates the Authorization Code + PKCE login flow. */
+  login: (options?: LoginOptions) => void;
+  /** Logs the user out and redirects to the OP's end-session endpoint. */
+  logout: () => void;
+  /** Uses the stored refresh token to obtain a new set of tokens. */
+  refresh: () => Promise<void>;
+  /** Fetches the user's profile from the userinfo endpoint. */
+  fetchProfile: () => Promise<void>;
+}
+
+/**
+ * The authentication state and actions exposed by the {@link useAuth} composable.
+ *
+ * Contains the current user, authentication status, tokens, and action methods.
+ */
+export interface AuthContextValue {
+  /** The OIDC configuration used to initialize the client. */
+  config: OidcConfig;
+  /** The authenticated user, or null if not logged in. */
+  user: AuthUser | null;
+  /** Whether the user is currently authenticated. */
+  isAuthenticated: boolean;
+  /** Whether initialization or a token exchange is in progress. */
+  isLoading: boolean;
+  /** The most recent authentication error, or null if none. */
+  error: Error | null;
+  /** Current set of OAuth 2.0 tokens. */
+  tokens: AuthTokens;
+  /** Actions for login, logout, refresh, and profile fetching. */
+  actions: AuthActions;
+}
+
+/**
+ * Options for the {@link oidcPlugin} Vue plugin.
+ *
+ * Configures the OIDC client with provider details, callback hooks,
+ * and optional behavior flags.
+ */
+export interface OidcPluginOptions {
+  /** OIDC configuration including issuer, clientId, and redirectUri. */
+  config: OidcConfig;
+  /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
+  fetchProfile?: boolean;
+  /** Callback invoked after a successful login with the returnTo path. */
+  onLogin?: (returnTo: string) => void;
+  /** Callback invoked when an authentication error occurs. */
+  onError?: (error: Error) => void;
+}

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src"]
+}

--- a/packages/vue/tsconfig.typedoc.json
+++ b/packages/vue/tsconfig.typedoc.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "lib": ["ES2022", "DOM"],
+    "paths": {
+      "oidc-js-core": ["../core/src/index.ts"],
+      "oidc-js": ["../client/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["src/tests"]
+}

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  plugins: [dts({ rollupTypes: true })],
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      formats: ["es", "cjs"],
+      fileName: (format) => `index.${format === "es" ? "js" : "cjs"}`,
+    },
+    sourcemap: true,
+    rollupOptions: {
+      external: ["vue", "oidc-js", "oidc-js-core"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,7 +167,30 @@ importers:
         specifier: ^4.0.0
         version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
 
-  packages/vue: {}
+  packages/vue:
+    dependencies:
+      oidc-js:
+        specifier: workspace:*
+        version: link:../client
+      oidc-js-core:
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite-plugin-dts:
+        specifier: ^4.0.0
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.33(typescript@5.9.3)
 
   tests/e2e:
     devDependencies:
@@ -246,6 +269,31 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
         version: 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+
+  tests/e2e/vue-app:
+    dependencies:
+      oidc-js-core:
+        specifier: workspace:*
+        version: link:../../../packages/core
+      oidc-js-vue:
+        specifier: workspace:*
+        version: link:../../../packages/vue
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.33(typescript@5.9.3)
+      vue-router:
+        specifier: ^4.5.0
+        version: 4.6.4(vue@3.5.33(typescript@5.9.3))
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.0
+        version: 6.0.6(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -1197,6 +1245,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
+  '@rolldown/pluginutils@1.0.0-rc.13':
+    resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
+
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
@@ -1693,6 +1744,13 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitejs/plugin-vue@6.0.6':
+    resolution: {integrity: sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
+
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
 
@@ -1737,8 +1795,17 @@ packages:
   '@vue/compiler-dom@3.5.33':
     resolution: {integrity: sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA==}
 
+  '@vue/compiler-sfc@3.5.33':
+    resolution: {integrity: sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA==}
+
+  '@vue/compiler-ssr@3.5.33':
+    resolution: {integrity: sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A==}
+
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/language-core@2.2.0':
     resolution: {integrity: sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==}
@@ -1747,6 +1814,20 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@vue/reactivity@3.5.33':
+    resolution: {integrity: sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A==}
+
+  '@vue/runtime-core@3.5.33':
+    resolution: {integrity: sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ==}
+
+  '@vue/runtime-dom@3.5.33':
+    resolution: {integrity: sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw==}
+
+  '@vue/server-renderer@3.5.33':
+    resolution: {integrity: sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw==}
+    peerDependencies:
+      vue: 3.5.33
 
   '@vue/shared@3.5.33':
     resolution: {integrity: sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ==}
@@ -4027,6 +4108,19 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  vue@3.5.33:
+    resolution: {integrity: sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -4984,6 +5078,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
+  '@rolldown/pluginutils@1.0.0-rc.13': {}
+
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
@@ -5514,6 +5610,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.13
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vue: 3.5.33(typescript@5.9.3)
+
   '@vitest/expect@4.1.5':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -5580,10 +5682,29 @@ snapshots:
       '@vue/compiler-core': 3.5.33
       '@vue/shared': 3.5.33
 
+  '@vue/compiler-sfc@3.5.33':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@vue/compiler-core': 3.5.33
+      '@vue/compiler-dom': 3.5.33
+      '@vue/compiler-ssr': 3.5.33
+      '@vue/shared': 3.5.33
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.13
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.33':
+    dependencies:
+      '@vue/compiler-dom': 3.5.33
+      '@vue/shared': 3.5.33
+
   '@vue/compiler-vue2@2.7.16':
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/language-core@2.2.0(typescript@5.9.3)':
     dependencies:
@@ -5597,6 +5718,28 @@ snapshots:
       path-browserify: 1.0.1
     optionalDependencies:
       typescript: 5.9.3
+
+  '@vue/reactivity@3.5.33':
+    dependencies:
+      '@vue/shared': 3.5.33
+
+  '@vue/runtime-core@3.5.33':
+    dependencies:
+      '@vue/reactivity': 3.5.33
+      '@vue/shared': 3.5.33
+
+  '@vue/runtime-dom@3.5.33':
+    dependencies:
+      '@vue/reactivity': 3.5.33
+      '@vue/runtime-core': 3.5.33
+      '@vue/shared': 3.5.33
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.33(vue@3.5.33(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.33
+      '@vue/shared': 3.5.33
+      vue: 3.5.33(typescript@5.9.3)
 
   '@vue/shared@3.5.33': {}
 
@@ -8442,6 +8585,21 @@ snapshots:
       vscode-languageserver-protocol: 3.17.5
 
   vscode-uri@3.1.0: {}
+
+  vue-router@4.6.4(vue@3.5.33(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.33(typescript@5.9.3)
+
+  vue@3.5.33(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.33
+      '@vue/compiler-sfc': 3.5.33
+      '@vue/runtime-dom': 3.5.33
+      '@vue/server-renderer': 3.5.33(vue@3.5.33(typescript@5.9.3))
+      '@vue/shared': 3.5.33
+    optionalDependencies:
+      typescript: 5.9.3
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,5 @@ packages:
   - "tests/e2e/react-app"
   - "tests/e2e/svelte-app"
   - "tests/e2e/lit-app"
+  - "tests/e2e/vue-app"
   - "docs-web"

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -6,6 +6,7 @@
     "test": "playwright test",
     "test:svelte": "playwright test --config playwright.svelte.config.ts",
     "test:lit": "playwright test --config playwright.lit.config.ts",
+    "test:vue": "playwright test --config=playwright.vue.config.ts",
     "test:ui": "playwright test --ui",
     "test:stress": "npx playwright test --repeat-each=100"
   },

--- a/tests/e2e/playwright.vue.config.ts
+++ b/tests/e2e/playwright.vue.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./specs",
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+  globalSetup: "./global-setup.ts",
+  globalTeardown: "./global-teardown.ts",
+  webServer: {
+    command: "pnpm --dir vue-app dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 15_000,
+  },
+});

--- a/tests/e2e/vue-app/index.html
+++ b/tests/e2e/vue-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OIDC E2E Test App (Vue)</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/tests/e2e/vue-app/package.json
+++ b/tests/e2e/vue-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "e2e-vue-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "oidc-js-core": "workspace:*",
+    "oidc-js-vue": "workspace:*",
+    "vue": "^3.5.0",
+    "vue-router": "^4.5.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^8.0.0"
+  }
+}

--- a/tests/e2e/vue-app/src/App.vue
+++ b/tests/e2e/vue-app/src/App.vue
@@ -1,0 +1,3 @@
+<template>
+  <router-view />
+</template>

--- a/tests/e2e/vue-app/src/main.ts
+++ b/tests/e2e/vue-app/src/main.ts
@@ -1,0 +1,39 @@
+import { createApp } from "vue";
+import { createRouter, createWebHistory } from "vue-router";
+import { oidcPlugin } from "oidc-js-vue";
+import App from "./App.vue";
+import Home from "./views/Home.vue";
+import Callback from "./views/Callback.vue";
+import ProtectedA from "./views/ProtectedA.vue";
+import ProtectedB from "./views/ProtectedB.vue";
+
+const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes: [
+    { path: "/", component: Home },
+    { path: "/callback", component: Callback },
+    { path: "/protected-a", component: ProtectedA },
+    { path: "/protected-b", component: ProtectedB },
+  ],
+});
+
+const app = createApp(App);
+
+app.use(oidcPlugin, {
+  config: {
+    issuer: "http://localhost:9999/oauth2",
+    clientId: "e2e-test-app",
+    redirectUri: "http://localhost:5173/callback",
+    scopes: ["openid", "profile", "email", "offline_access"],
+    postLogoutRedirectUri: "http://localhost:5173",
+  },
+  fetchProfile,
+  onLogin(returnTo: string) {
+    router.replace(returnTo);
+  },
+});
+
+app.use(router);
+app.mount("#app");

--- a/tests/e2e/vue-app/src/views/Callback.vue
+++ b/tests/e2e/vue-app/src/views/Callback.vue
@@ -1,0 +1,3 @@
+<template>
+  <div data-testid="auth-loading">Processing login...</div>
+</template>

--- a/tests/e2e/vue-app/src/views/Home.vue
+++ b/tests/e2e/vue-app/src/views/Home.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { useAuth } from "oidc-js-vue";
+
+const { user, isAuthenticated, isLoading, error, tokens, actions } = useAuth();
+</script>
+
+<template>
+  <div v-if="isLoading" data-testid="auth-loading">Loading...</div>
+  <div v-else-if="error" data-testid="auth-error">Error: {{ error.message }}</div>
+  <div v-else-if="!isAuthenticated" data-testid="unauthenticated">
+    <h1>Not logged in</h1>
+    <button data-testid="login-button" @click="actions.login()">Login</button>
+  </div>
+  <div v-else data-testid="authenticated">
+    <h1>Logged in</h1>
+    <div data-testid="user-sub">{{ user?.claims.sub }}</div>
+    <div data-testid="user-iss">{{ user?.claims.iss }}</div>
+    <div data-testid="user-aud">{{ typeof user?.claims.aud === "string" ? user.claims.aud : JSON.stringify(user?.claims.aud) }}</div>
+    <div data-testid="user-exp">{{ user?.claims.exp }}</div>
+    <div data-testid="user-iat">{{ user?.claims.iat }}</div>
+    <div data-testid="user-email">{{ user?.profile?.email ?? "no profile" }}</div>
+    <div data-testid="user-profile-null">{{ user?.profile === null ? "true" : "false" }}</div>
+    <div data-testid="access-token">{{ tokens.access ? "present" : "missing" }}</div>
+    <div data-testid="refresh-token">{{ tokens.refresh ? "present" : "missing" }}</div>
+    <div data-testid="access-token-value" style="display: none">{{ tokens.access ?? "" }}</div>
+    <div data-testid="refresh-token-value" style="display: none">{{ tokens.refresh ?? "" }}</div>
+    <div data-testid="id-token">{{ tokens.id ? "present" : "missing" }}</div>
+    <div data-testid="expires-at">{{ tokens.expiresAt ?? "none" }}</div>
+    <button data-testid="logout-button" @click="actions.logout()">Logout</button>
+    <button data-testid="refresh-button" @click="actions.refresh().catch(() => {})">Refresh</button>
+    <nav>
+      <router-link data-testid="link-protected-a" to="/protected-a">Protected A</router-link>
+      <router-link data-testid="link-protected-b" to="/protected-b">Protected B</router-link>
+    </nav>
+  </div>
+</template>

--- a/tests/e2e/vue-app/src/views/ProtectedA.vue
+++ b/tests/e2e/vue-app/src/views/ProtectedA.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { RequireAuth } from "oidc-js-vue";
+</script>
+
+<template>
+  <RequireAuth>
+    <template #fallback>
+      <div data-testid="auth-loading">Refreshing...</div>
+    </template>
+    <div data-testid="protected-a">Protected content a</div>
+    <nav>
+      <router-link data-testid="link-home" to="/">Home</router-link>
+      <router-link data-testid="link-protected-a" to="/protected-a">Protected A</router-link>
+      <router-link data-testid="link-protected-b" to="/protected-b">Protected B</router-link>
+    </nav>
+  </RequireAuth>
+</template>

--- a/tests/e2e/vue-app/src/views/ProtectedB.vue
+++ b/tests/e2e/vue-app/src/views/ProtectedB.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { RequireAuth } from "oidc-js-vue";
+</script>
+
+<template>
+  <RequireAuth>
+    <template #fallback>
+      <div data-testid="auth-loading">Refreshing...</div>
+    </template>
+    <div data-testid="protected-b">Protected content b</div>
+    <nav>
+      <router-link data-testid="link-home" to="/">Home</router-link>
+      <router-link data-testid="link-protected-a" to="/protected-a">Protected A</router-link>
+      <router-link data-testid="link-protected-b" to="/protected-b">Protected B</router-link>
+    </nav>
+  </RequireAuth>
+</template>

--- a/tests/e2e/vue-app/tsconfig.json
+++ b/tests/e2e/vue-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/tests/e2e/vue-app/vite.config.ts
+++ b/tests/e2e/vue-app/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+
+export default defineConfig({
+  plugins: [vue()],
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `packages/vue/` (`oidc-js-vue`) with plugin, composable, navigation guard
- Vue 3 Composition API: `oidcPlugin`, `useAuth()`, `createAuthGuard()`
- E2E test app at `tests/e2e/vue-app/` with full data-testid contract
- Playwright config and test script wired up

## Test plan
- [ ] `pnpm --filter oidc-js-vue build` passes
- [ ] `pnpm --filter e2e-tests test:vue` passes
- [ ] All shared E2E specs pass against Vue test app

🤖 Generated with [Claude Code](https://claude.com/claude-code)