### PR TITLE
feat: add Svelte adapter package and E2E test app

### DIFF
--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,8 +1,47 @@
 {
   "name": "oidc-js-svelte",
   "version": "0.0.1",
-  "description": "Svelte bindings for oidc-js (coming soon)",
-  "license": "MIT",
+  "description": "Svelte 5 bindings for oidc-js",
+  "type": "module",
+  "svelte": "./dist/index.js",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": [
+    "oidc",
+    "openid",
+    "oauth2",
+    "svelte",
+    "authentication"
+  ],
   "author": "eugenioenko",
-  "keywords": ["oidc", "openid", "oauth2", "svelte", "authentication"]
+  "license": "MIT",
+  "dependencies": {
+    "oidc-js": "workspace:*",
+    "oidc-js-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "svelte": ">=5.0.0"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "svelte": "^5.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^8.0.0",
+    "vite-plugin-dts": "^4.0.0"
+  }
 }

--- a/packages/svelte/src/AuthProvider.svelte
+++ b/packages/svelte/src/AuthProvider.svelte
@@ -1,0 +1,64 @@
+<!--
+  @component
+  Provides OIDC authentication context to all child components.
+
+  Wraps the application (or a subtree) and manages the full OIDC lifecycle:
+  discovery, callback handling, token management, and logout.
+
+  Uses `setContext()` internally so that child components can call
+  `getAuthContext()` to access reactive auth state and actions.
+
+  @example
+  ```svelte
+  <AuthProvider config={oidcConfig}>
+    <App />
+  </AuthProvider>
+  ```
+-->
+<script lang="ts">
+  import type { OidcConfig } from "oidc-js-core";
+  import type { Snippet } from "svelte";
+  import { onDestroy } from "svelte";
+  import { AuthStateManager, setAuthContext } from "./context.svelte.js";
+
+  interface Props {
+    /** OIDC configuration including issuer, clientId, and redirectUri. */
+    config: OidcConfig;
+    /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
+    fetchProfile?: boolean;
+    /** Callback invoked after a successful login with the returnTo path. */
+    onLogin?: (returnTo: string) => void;
+    /** Callback invoked when an authentication error occurs. */
+    onError?: (error: Error) => void;
+    /** Child content to render. */
+    children: Snippet;
+  }
+
+  let { config, fetchProfile = true, onLogin, onError, children }: Props = $props();
+
+  const manager = new AuthStateManager(config, fetchProfile);
+  setAuthContext(manager);
+
+  const unsub = manager.client.subscribe((state) => {
+    manager.update(state);
+  });
+
+  manager.client.init().then(({ returnTo }) => {
+    const s = manager.client.state;
+    if (s.error && onError) onError(s.error);
+    if (returnTo) {
+      if (onLogin) {
+        onLogin(returnTo);
+      } else {
+        window.history.replaceState({}, "", returnTo);
+      }
+    }
+  });
+
+  onDestroy(() => {
+    unsub();
+    manager.client.destroy();
+  });
+</script>
+
+{@render children()}

--- a/packages/svelte/src/RequireAuth.svelte
+++ b/packages/svelte/src/RequireAuth.svelte
@@ -1,0 +1,68 @@
+<!--
+  @component
+  Guards child content behind authentication.
+
+  When the user is not authenticated, it attempts to refresh the token.
+  If refresh fails or no refresh token exists, it redirects to login.
+  While loading or refreshing, it renders the optional `fallback` snippet.
+
+  @example
+  ```svelte
+  <RequireAuth>
+    {#snippet children()}
+      <ProtectedContent />
+    {/snippet}
+    {#snippet fallback()}
+      <p>Loading...</p>
+    {/snippet}
+  </RequireAuth>
+  ```
+-->
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import type { LoginOptions } from "oidc-js";
+  import { getAuthContext } from "./context.svelte.js";
+
+  interface Props {
+    /** Child content rendered when the user is authenticated. */
+    children: Snippet;
+    /** Content rendered while loading or refreshing. Defaults to nothing. */
+    fallback?: Snippet;
+    /** Whether to automatically refresh an expired token. Defaults to true. */
+    autoRefresh?: boolean;
+    /** Options to pass to the login redirect if authentication is required. */
+    loginOptions?: LoginOptions;
+  }
+
+  let { children, fallback, autoRefresh = true, loginOptions }: Props = $props();
+
+  const auth = getAuthContext();
+  let refreshAttempted = false;
+
+  $effect(() => {
+    const isExpired = auth.tokens.expiresAt !== null && auth.tokens.expiresAt <= Date.now();
+    const needsAuth = !auth.isAuthenticated || isExpired;
+
+    if (!needsAuth) {
+      refreshAttempted = false;
+      return;
+    }
+    if (auth.isLoading) return;
+
+    if (autoRefresh && !refreshAttempted) {
+      refreshAttempted = true;
+      auth.actions.refresh().catch(() => auth.actions.login(loginOptions));
+      return;
+    }
+
+    auth.actions.login(loginOptions);
+  });
+</script>
+
+{#if auth.isLoading || !auth.isAuthenticated || (auth.tokens.expiresAt !== null && auth.tokens.expiresAt <= Date.now())}
+  {#if fallback}
+    {@render fallback()}
+  {/if}
+{:else}
+  {@render children()}
+{/if}

--- a/packages/svelte/src/context.svelte.ts
+++ b/packages/svelte/src/context.svelte.ts
@@ -1,0 +1,96 @@
+import { getContext, setContext } from "svelte";
+import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
+import type { OidcConfig } from "oidc-js-core";
+import type { AuthContextValue, AuthActions } from "./types.js";
+
+const AUTH_CONTEXT_KEY = Symbol("oidc-js-auth");
+
+/**
+ * Reactive authentication state container using Svelte 5 runes.
+ *
+ * Created internally by {@link AuthProvider} and shared via Svelte's context API.
+ * Consumers access it through {@link getAuthContext}.
+ */
+export class AuthStateManager {
+  private _user: AuthState["user"] = $state(null);
+  private _isAuthenticated: boolean = $state(false);
+  private _isLoading: boolean = $state(true);
+  private _error: AuthState["error"] = $state(null);
+  private _tokens: AuthState["tokens"] = $state({
+    access: null,
+    id: null,
+    refresh: null,
+    expiresAt: null,
+  });
+
+  readonly config: OidcConfig;
+  readonly client: OidcClient;
+  readonly actions: AuthActions;
+
+  constructor(config: OidcConfig, fetchProfile: boolean) {
+    this.config = config;
+    this.client = new OidcClient({ ...config, fetchProfile });
+
+    this.actions = {
+      login: (options?: LoginOptions) => {
+        this.client.login(options);
+      },
+      logout: () => {
+        this.client.logout();
+      },
+      refresh: () => this.client.refresh(),
+      fetchProfile: () => this.client.fetchProfile(),
+    };
+  }
+
+  /** Updates the reactive state from an {@link AuthState} snapshot. */
+  update(state: AuthState): void {
+    this._user = state.user;
+    this._isAuthenticated = state.isAuthenticated;
+    this._isLoading = state.isLoading;
+    this._error = state.error;
+    this._tokens = state.tokens;
+  }
+
+  get user() { return this._user; }
+  get isAuthenticated() { return this._isAuthenticated; }
+  get isLoading() { return this._isLoading; }
+  get error() { return this._error; }
+  get tokens() { return this._tokens; }
+}
+
+/**
+ * Sets the auth context value for child components.
+ *
+ * Called internally by the AuthProvider component.
+ *
+ * @param manager - The reactive auth state manager.
+ */
+export function setAuthContext(manager: AuthStateManager): void {
+  setContext(AUTH_CONTEXT_KEY, manager);
+}
+
+/**
+ * Retrieves the authentication context from the nearest {@link AuthProvider} ancestor.
+ *
+ * Must be called during component initialization (not inside event handlers or async callbacks).
+ *
+ * @returns The reactive authentication context value.
+ * @throws Error if called outside of an AuthProvider.
+ */
+export function getAuthContext(): AuthContextValue {
+  const manager = getContext<AuthStateManager | undefined>(AUTH_CONTEXT_KEY);
+  if (!manager) {
+    throw new Error("getAuthContext must be used within an AuthProvider");
+  }
+
+  return {
+    get config() { return manager.config; },
+    get user() { return manager.user; },
+    get isAuthenticated() { return manager.isAuthenticated; },
+    get isLoading() { return manager.isLoading; },
+    get error() { return manager.error; },
+    get tokens() { return manager.tokens; },
+    get actions() { return manager.actions; },
+  };
+}

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,0 +1,14 @@
+export { default as AuthProvider } from "./AuthProvider.svelte";
+export { default as RequireAuth } from "./RequireAuth.svelte";
+export { getAuthContext } from "./context.svelte.js";
+
+export type {
+  IdTokenClaims,
+  AuthUser,
+  AuthTokens,
+  AuthActions,
+  AuthContextValue,
+  LoginOptions,
+} from "./types.js";
+
+export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -1,0 +1,35 @@
+import type { OidcConfig } from "oidc-js-core";
+
+export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+
+import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+
+/** Actions available to interact with the OIDC authentication flow. */
+export interface AuthActions {
+  /** Initiates the login flow by redirecting to the authorization endpoint. */
+  login: (options?: LoginOptions) => void;
+  /** Logs the user out and redirects to the end-session endpoint. */
+  logout: () => void;
+  /** Refreshes the access token using the stored refresh token. */
+  refresh: () => Promise<void>;
+  /** Fetches the user's profile from the userinfo endpoint. */
+  fetchProfile: () => Promise<void>;
+}
+
+/** Reactive authentication context value provided by {@link AuthProvider}. */
+export interface AuthContextValue {
+  /** The OIDC configuration used by the provider. */
+  readonly config: OidcConfig;
+  /** The authenticated user, or null if not logged in. */
+  readonly user: AuthUser | null;
+  /** Whether the user is currently authenticated. */
+  readonly isAuthenticated: boolean;
+  /** Whether initialization or a token exchange is in progress. */
+  readonly isLoading: boolean;
+  /** The most recent authentication error, or null if none. */
+  readonly error: Error | null;
+  /** Current set of OAuth 2.0 tokens. */
+  readonly tokens: AuthTokens;
+  /** Actions to interact with the authentication flow. */
+  readonly actions: AuthActions;
+}

--- a/packages/svelte/tsconfig.json
+++ b/packages/svelte/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src"]
+}

--- a/packages/svelte/tsconfig.typedoc.json
+++ b/packages/svelte/tsconfig.typedoc.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true
+  }
+}

--- a/packages/svelte/vite.config.ts
+++ b/packages/svelte/vite.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  plugins: [
+    svelte(),
+    dts({ rollupTypes: true }),
+  ],
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      formats: ["es"],
+      fileName: () => "index.js",
+    },
+    sourcemap: true,
+    rollupOptions: {
+      external: ["svelte", "svelte/internal", "svelte/store", "oidc-js", "oidc-js-core"],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,30 @@ importers:
 
   packages/solid: {}
 
-  packages/svelte: {}
+  packages/svelte:
+    dependencies:
+      oidc-js:
+        specifier: workspace:*
+        version: link:../client
+      oidc-js-core:
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.0
+        version: 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      svelte:
+        specifier: ^5.0.0
+        version: 5.55.5(@typescript-eslint/types@8.59.1)
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vite-plugin-dts:
+        specifier: ^4.0.0
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
 
   packages/vue: {}
 
@@ -160,6 +183,28 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.7.0(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+
+  tests/e2e/svelte-app:
+    dependencies:
+      oidc-js-core:
+        specifier: workspace:*
+        version: link:../../../packages/core
+      oidc-js-svelte:
+        specifier: workspace:*
+        version: link:../../../packages/svelte
+      svelte:
+        specifier: ^5.0.0
+        version: 5.55.5(@typescript-eslint/types@8.59.1)
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.0
+        version: 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
       typescript:
         specifier: ^5.5.0
         version: 5.9.3
@@ -1309,6 +1354,26 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@sveltejs/acorn-typescript@1.0.9':
+    resolution: {integrity: sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==}
+    peerDependencies:
+      acorn: ^8.9.0
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1':
+    resolution: {integrity: sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      '@sveltejs/vite-plugin-svelte': ^5.0.0
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
+  '@sveltejs/vite-plugin-svelte@5.1.1':
+    resolution: {integrity: sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22}
+    peerDependencies:
+      svelte: ^5.0.0
+      vite: ^6.0.0
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -1713,6 +1778,10 @@ packages:
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
+  aria-query@5.3.1:
+    resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
+    engines: {node: '>= 0.4'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -2111,6 +2180,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -2253,6 +2326,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -2260,6 +2336,14 @@ packages:
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
+
+  esrap@2.2.5:
+    resolution: {integrity: sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==}
+    peerDependencies:
+      '@typescript-eslint/types': ^8.2.0
+    peerDependenciesMeta:
+      '@typescript-eslint/types':
+        optional: true
 
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
@@ -2581,6 +2665,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
@@ -2644,6 +2731,10 @@ packages:
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
   klona@2.0.6:
@@ -2747,6 +2838,9 @@ packages:
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
+
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -3464,6 +3558,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svelte@5.55.5:
+    resolution: {integrity: sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==}
+    engines: {node: '>=18'}
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -3972,6 +4070,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -4980,6 +5081,32 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+    dependencies:
+      acorn: 8.16.0
+
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      debug: 4.4.3
+      svelte: 5.55.5(@typescript-eslint/types@8.59.1)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))':
+    dependencies:
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)))(svelte@5.55.5(@typescript-eslint/types@8.59.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+      debug: 4.4.3
+      deepmerge: 4.3.1
+      kleur: 4.1.5
+      magic-string: 0.30.21
+      svelte: 5.55.5(@typescript-eslint/types@8.59.1)
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+      vitefu: 1.1.3(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -5209,8 +5336,7 @@ snapshots:
     dependencies:
       '@types/node': 25.6.0
 
-  '@types/trusted-types@2.0.7':
-    optional: true
+  '@types/trusted-types@2.0.7': {}
 
   '@types/unist@2.0.11': {}
 
@@ -5472,6 +5598,8 @@ snapshots:
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
+
+  aria-query@5.3.1: {}
 
   aria-query@5.3.2: {}
 
@@ -5960,6 +6088,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.3.1: {}
+
   defu@6.1.7: {}
 
   delaunator@5.1.0:
@@ -6156,6 +6286,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@11.2.0:
     dependencies:
       acorn: 8.16.0
@@ -6165,6 +6297,12 @@ snapshots:
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
+
+  esrap@2.2.5(@typescript-eslint/types@8.59.1):
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+    optionalDependencies:
+      '@typescript-eslint/types': 8.59.1
 
   esrecurse@4.3.0:
     dependencies:
@@ -6584,6 +6722,10 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
@@ -6654,6 +6796,8 @@ snapshots:
   khroma@2.1.0: {}
 
   kleur@3.0.3: {}
+
+  kleur@4.1.5: {}
 
   klona@2.0.6: {}
 
@@ -6735,6 +6879,8 @@ snapshots:
       mlly: 1.8.2
       pkg-types: 2.3.1
       quansync: 0.2.11
+
+  locate-character@3.0.0: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -7895,6 +8041,27 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svelte@5.55.5(@typescript-eslint/types@8.59.1):
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@types/estree': 1.0.8
+      '@types/trusted-types': 2.0.7
+      acorn: 8.16.0
+      aria-query: 5.3.1
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.8.0
+      esm-env: 1.2.2
+      esrap: 2.2.5(@typescript-eslint/types@8.59.1)
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - '@typescript-eslint/types'
+
   svgo@4.0.1:
     dependencies:
       commander: 11.1.0
@@ -8149,6 +8316,10 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(yaml@2.8.3)
 
+  vitefu@1.1.3(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)):
+    optionalDependencies:
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)
+
   vitest@4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
@@ -8259,6 +8430,8 @@ snapshots:
       yoctocolors: 2.1.2
 
   yoctocolors@2.1.2: {}
+
+  zimmerframe@1.1.4: {}
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,5 @@ packages:
   - "packages/*"
   - "tests/e2e"
   - "tests/e2e/react-app"
+  - "tests/e2e/svelte-app"
   - "docs-web"

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "test": "playwright test",
+    "test:svelte": "playwright test --config playwright.svelte.config.ts",
     "test:ui": "playwright test --ui",
     "test:stress": "npx playwright test --repeat-each=100"
   },

--- a/tests/e2e/playwright.svelte.config.ts
+++ b/tests/e2e/playwright.svelte.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./specs",
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+  globalSetup: "./global-setup.ts",
+  globalTeardown: "./global-teardown.ts",
+  webServer: {
+    command: "pnpm --dir svelte-app dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 15_000,
+  },
+});

--- a/tests/e2e/svelte-app/index.html
+++ b/tests/e2e/svelte-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OIDC E2E Test App (Svelte)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/tests/e2e/svelte-app/package.json
+++ b/tests/e2e/svelte-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "e2e-svelte-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "oidc-js-core": "workspace:*",
+    "oidc-js-svelte": "workspace:*",
+    "svelte": "^5.0.0"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^8.0.0"
+  }
+}

--- a/tests/e2e/svelte-app/src/App.svelte
+++ b/tests/e2e/svelte-app/src/App.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+  import { AuthProvider } from "oidc-js-svelte";
+  import Home from "./routes/Home.svelte";
+  import Callback from "./routes/Callback.svelte";
+  import ProtectedA from "./routes/ProtectedA.svelte";
+  import ProtectedB from "./routes/ProtectedB.svelte";
+
+  const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+
+  const config = {
+    issuer: "http://localhost:9999/oauth2",
+    clientId: "e2e-test-app",
+    redirectUri: "http://localhost:5173/callback",
+    scopes: ["openid", "profile", "email", "offline_access"],
+    postLogoutRedirectUri: "http://localhost:5173",
+  };
+
+  let path = $state(window.location.pathname);
+
+  function navigate(to: string) {
+    window.history.pushState({}, "", to);
+    path = to;
+  }
+
+  function handleLogin(returnTo: string) {
+    window.history.replaceState({}, "", returnTo);
+    path = returnTo;
+  }
+
+  $effect(() => {
+    function onPopState() {
+      path = window.location.pathname;
+    }
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  });
+</script>
+
+<AuthProvider {config} {fetchProfile} onLogin={handleLogin}>
+  {#snippet children()}
+    {#if path === "/callback"}
+      <Callback />
+    {:else if path === "/protected-a"}
+      <ProtectedA {navigate} />
+    {:else if path === "/protected-b"}
+      <ProtectedB {navigate} />
+    {:else}
+      <Home {navigate} />
+    {/if}
+  {/snippet}
+</AuthProvider>

--- a/tests/e2e/svelte-app/src/main.ts
+++ b/tests/e2e/svelte-app/src/main.ts
@@ -1,0 +1,6 @@
+import { mount } from "svelte";
+import App from "./App.svelte";
+
+const root = document.getElementById("root")!;
+
+mount(App, { target: root });

--- a/tests/e2e/svelte-app/src/routes/Callback.svelte
+++ b/tests/e2e/svelte-app/src/routes/Callback.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+  // The callback page simply shows a loading indicator while
+  // the AuthProvider processes the authorization code exchange.
+</script>
+
+<div data-testid="auth-loading">Processing login...</div>

--- a/tests/e2e/svelte-app/src/routes/Home.svelte
+++ b/tests/e2e/svelte-app/src/routes/Home.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { getAuthContext } from "oidc-js-svelte";
+
+  interface Props {
+    navigate: (to: string) => void;
+  }
+
+  let { navigate }: Props = $props();
+
+  const auth = getAuthContext();
+
+  function goTo(e: MouseEvent, path: string) {
+    e.preventDefault();
+    navigate(path);
+  }
+</script>
+
+{#if auth.isLoading}
+  <div data-testid="auth-loading">Loading...</div>
+{:else if auth.error}
+  <div data-testid="auth-error">Error: {auth.error.message}</div>
+{:else if !auth.isAuthenticated}
+  <div data-testid="unauthenticated">
+    <h1>Not logged in</h1>
+    <button data-testid="login-button" onclick={() => auth.actions.login()}>
+      Login
+    </button>
+  </div>
+{:else}
+  <div data-testid="authenticated">
+    <h1>Logged in</h1>
+    <div data-testid="user-sub">{auth.user?.claims.sub}</div>
+    <div data-testid="user-iss">{auth.user?.claims.iss}</div>
+    <div data-testid="user-aud">{typeof auth.user?.claims.aud === "string" ? auth.user.claims.aud : JSON.stringify(auth.user?.claims.aud)}</div>
+    <div data-testid="user-exp">{auth.user?.claims.exp}</div>
+    <div data-testid="user-iat">{auth.user?.claims.iat}</div>
+    <div data-testid="user-email">{auth.user?.profile?.email ?? "no profile"}</div>
+    <div data-testid="user-profile-null">{auth.user?.profile === null ? "true" : "false"}</div>
+    <div data-testid="access-token">{auth.tokens.access ? "present" : "missing"}</div>
+    <div data-testid="refresh-token">{auth.tokens.refresh ? "present" : "missing"}</div>
+    <div data-testid="access-token-value" style="display: none">{auth.tokens.access ?? ""}</div>
+    <div data-testid="refresh-token-value" style="display: none">{auth.tokens.refresh ?? ""}</div>
+    <div data-testid="id-token">{auth.tokens.id ? "present" : "missing"}</div>
+    <div data-testid="expires-at">{auth.tokens.expiresAt ?? "none"}</div>
+    <button data-testid="logout-button" onclick={() => auth.actions.logout()}>
+      Logout
+    </button>
+    <button data-testid="refresh-button" onclick={() => auth.actions.refresh().catch(() => {})}>
+      Refresh
+    </button>
+    <nav>
+      <a href="/protected-a" data-testid="link-protected-a" onclick={(e) => goTo(e, "/protected-a")}>Protected A</a>
+      <a href="/protected-b" data-testid="link-protected-b" onclick={(e) => goTo(e, "/protected-b")}>Protected B</a>
+    </nav>
+  </div>
+{/if}

--- a/tests/e2e/svelte-app/src/routes/ProtectedA.svelte
+++ b/tests/e2e/svelte-app/src/routes/ProtectedA.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { RequireAuth } from "oidc-js-svelte";
+
+  interface Props {
+    navigate: (to: string) => void;
+  }
+
+  let { navigate }: Props = $props();
+
+  function goTo(e: MouseEvent, path: string) {
+    e.preventDefault();
+    navigate(path);
+  }
+</script>
+
+<RequireAuth>
+  {#snippet children()}
+    <div data-testid="protected-a">
+      Protected content a
+    </div>
+    <nav>
+      <a href="/" data-testid="link-home" onclick={(e) => goTo(e, "/")}>Home</a>
+      <a href="/protected-a" data-testid="link-protected-a" onclick={(e) => goTo(e, "/protected-a")}>Protected A</a>
+      <a href="/protected-b" data-testid="link-protected-b" onclick={(e) => goTo(e, "/protected-b")}>Protected B</a>
+    </nav>
+  {/snippet}
+  {#snippet fallback()}
+    <div data-testid="auth-loading">Refreshing...</div>
+  {/snippet}
+</RequireAuth>

--- a/tests/e2e/svelte-app/src/routes/ProtectedB.svelte
+++ b/tests/e2e/svelte-app/src/routes/ProtectedB.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { RequireAuth } from "oidc-js-svelte";
+
+  interface Props {
+    navigate: (to: string) => void;
+  }
+
+  let { navigate }: Props = $props();
+
+  function goTo(e: MouseEvent, path: string) {
+    e.preventDefault();
+    navigate(path);
+  }
+</script>
+
+<RequireAuth>
+  {#snippet children()}
+    <div data-testid="protected-b">
+      Protected content b
+    </div>
+    <nav>
+      <a href="/" data-testid="link-home" onclick={(e) => goTo(e, "/")}>Home</a>
+      <a href="/protected-a" data-testid="link-protected-a" onclick={(e) => goTo(e, "/protected-a")}>Protected A</a>
+      <a href="/protected-b" data-testid="link-protected-b" onclick={(e) => goTo(e, "/protected-b")}>Protected B</a>
+    </nav>
+  {/snippet}
+  {#snippet fallback()}
+    <div data-testid="auth-loading">Refreshing...</div>
+  {/snippet}
+</RequireAuth>

--- a/tests/e2e/svelte-app/svelte.config.js
+++ b/tests/e2e/svelte-app/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/tests/e2e/svelte-app/tsconfig.json
+++ b/tests/e2e/svelte-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/tests/e2e/svelte-app/vite.config.ts
+++ b/tests/e2e/svelte-app/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+
+export default defineConfig({
+  plugins: [svelte()],
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `packages/svelte/` (`oidc-js-svelte`) with Svelte 5 runes and context
- `AuthProvider.svelte`, `getAuthContext()`, `RequireAuth.svelte`
- E2E test app at `tests/e2e/svelte-app/` with full data-testid contract
- Playwright config and test script wired up

## Test plan
- [ ] `pnpm --filter oidc-js-svelte build` passes
- [ ] `pnpm --filter e2e-tests test:svelte` passes
- [ ] All shared E2E specs pass against Svelte test app

🤖 Generated with [Claude Code](https://claude.com/claude-code)