### PR TITLE
feat: add Preact adapter package and E2E test app

### DIFF
--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "oidc-js-preact",
+  "version": "0.0.1",
+  "description": "Preact bindings for oidc-js",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": [
+    "oidc",
+    "openid",
+    "oauth2",
+    "preact",
+    "authentication"
+  ],
+  "author": "eugenioenko",
+  "license": "MIT",
+  "dependencies": {
+    "oidc-js": "workspace:*",
+    "oidc-js-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "preact": ">=10.0.0"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "^2.9.0",
+    "preact": "^10.0.0",
+    "typescript": "^5.5.0",
+    "vite": "^8.0.0",
+    "vite-plugin-dts": "^4.0.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/packages/preact/src/auth-required.tsx
+++ b/packages/preact/src/auth-required.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "preact/hooks";
+import type { ComponentChildren } from "preact";
+import { useAuth } from "./context.js";
+import type { LoginOptions } from "oidc-js";
+
+interface RequireAuthProps {
+  children: ComponentChildren;
+  fallback?: ComponentChildren;
+  autoRefresh?: boolean;
+  loginOptions?: LoginOptions;
+}
+
+/**
+ * Auth guard component that protects its children behind authentication.
+ *
+ * If the user is not authenticated, it attempts a silent token refresh (when `autoRefresh`
+ * is enabled and a refresh token exists). If refresh fails or is disabled, it redirects
+ * to the login page. While loading or refreshing, it renders the optional `fallback`.
+ *
+ * @param props - Guard configuration including children, fallback UI, and login options.
+ */
+export function RequireAuth({
+  children,
+  fallback = null,
+  autoRefresh = true,
+  loginOptions,
+}: RequireAuthProps) {
+  const { isAuthenticated, isLoading, tokens, actions } = useAuth();
+  const refreshAttempted = useRef(false);
+
+  const isExpired = tokens.expiresAt !== null && tokens.expiresAt <= Date.now();
+  const needsAuth = !isAuthenticated || isExpired;
+
+  useEffect(() => {
+    if (!needsAuth) {
+      refreshAttempted.current = false;
+      return;
+    }
+    if (isLoading) return;
+
+    if (autoRefresh && !refreshAttempted.current) {
+      refreshAttempted.current = true;
+      actions.refresh().catch(() => actions.login(loginOptions));
+      return;
+    }
+
+    actions.login(loginOptions);
+  }, [isLoading, needsAuth, autoRefresh, actions, loginOptions]);
+
+  if (isLoading || needsAuth) {
+    return fallback;
+  }
+
+  return children;
+}

--- a/packages/preact/src/context.tsx
+++ b/packages/preact/src/context.tsx
@@ -1,0 +1,126 @@
+import { createContext } from "preact";
+import {
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  useMemo,
+} from "preact/hooks";
+import type { ComponentChildren } from "preact";
+import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
+import type { OidcConfig } from "oidc-js-core";
+import type { AuthContextValue } from "./types.js";
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface AuthProviderProps {
+  config: OidcConfig;
+  fetchProfile?: boolean;
+  onLogin?: (returnTo: string) => void;
+  onError?: (error: Error) => void;
+  children: ComponentChildren;
+}
+
+/**
+ * Provides OIDC authentication state and actions to all child components.
+ *
+ * Wraps the application (or a subtree) to make {@link useAuth} available.
+ * Handles OIDC discovery, callback processing, and token lifecycle automatically.
+ *
+ * @param props - Provider configuration including OIDC config, optional callbacks, and children.
+ */
+export function AuthProvider({
+  config,
+  fetchProfile = true,
+  onLogin,
+  onError,
+  children,
+}: AuthProviderProps) {
+  const clientRef = useRef<OidcClient | null>(null);
+  const [state, setState] = useState<AuthState>(() => ({
+    user: null,
+    isAuthenticated: false,
+    isLoading: true,
+    error: null,
+    tokens: { access: null, id: null, refresh: null, expiresAt: null },
+  }));
+
+  const onLoginRef = useRef(onLogin);
+  onLoginRef.current = onLogin;
+
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  useEffect(() => {
+    const client = new OidcClient({ ...config, fetchProfile });
+    clientRef.current = client;
+
+    const unsub = client.subscribe(setState);
+
+    client.init().then(({ returnTo }) => {
+      const s = client.state;
+      if (s.error) onErrorRef.current?.(s.error);
+      if (returnTo) {
+        if (onLoginRef.current) {
+          onLoginRef.current(returnTo);
+        } else {
+          window.history.replaceState({}, "", returnTo);
+        }
+      }
+    });
+
+    return () => {
+      unsub();
+      client.destroy();
+    };
+  }, [config, fetchProfile]);
+
+  const login = useCallback(
+    async (options?: LoginOptions) => {
+      await clientRef.current?.login(options);
+    },
+    [],
+  );
+
+  const logout = useCallback(() => {
+    clientRef.current?.logout();
+  }, []);
+
+  const refresh = useCallback(async () => {
+    await clientRef.current?.refresh();
+  }, []);
+
+  const doFetchProfile = useCallback(async () => {
+    await clientRef.current?.fetchProfile();
+  }, []);
+
+  const actions = useMemo(
+    () => ({ login, logout, refresh, fetchProfile: doFetchProfile }),
+    [login, logout, refresh, doFetchProfile],
+  );
+
+  const value: AuthContextValue = useMemo(
+    () => ({ config, ...state, actions }),
+    [config, state, actions],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+/**
+ * Returns the current authentication context value.
+ *
+ * Must be called inside an {@link AuthProvider}. Provides access to the current
+ * user, authentication state, tokens, and actions (login, logout, refresh, fetchProfile).
+ *
+ * @returns The current {@link AuthContextValue}.
+ * @throws Error if called outside of an AuthProvider.
+ */
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return context;
+}

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -1,0 +1,13 @@
+export { AuthProvider, useAuth } from "./context.js";
+export { RequireAuth } from "./auth-required.js";
+
+export type {
+  IdTokenClaims,
+  AuthUser,
+  AuthTokens,
+  AuthActions,
+  AuthContextValue,
+  LoginOptions,
+} from "./types.js";
+
+export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/preact/src/types.ts
+++ b/packages/preact/src/types.ts
@@ -1,0 +1,35 @@
+import type { OidcConfig } from "oidc-js-core";
+
+export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+
+import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+
+/** Actions available for controlling the authentication lifecycle. */
+export interface AuthActions {
+  /** Initiates the OIDC login flow. */
+  login: (options?: LoginOptions) => void;
+  /** Logs the user out and optionally redirects to the OP's end-session endpoint. */
+  logout: () => void;
+  /** Refreshes the access token using the stored refresh token. */
+  refresh: () => Promise<void>;
+  /** Fetches the user's profile from the userinfo endpoint. */
+  fetchProfile: () => Promise<void>;
+}
+
+/** The value provided by {@link AuthProvider} and consumed by {@link useAuth}. */
+export interface AuthContextValue {
+  /** The OIDC configuration used by the provider. */
+  config: OidcConfig;
+  /** The authenticated user, or null if not logged in. */
+  user: AuthUser | null;
+  /** Whether the user is currently authenticated. */
+  isAuthenticated: boolean;
+  /** Whether initialization or a token exchange is in progress. */
+  isLoading: boolean;
+  /** The most recent authentication error, or null if none. */
+  error: Error | null;
+  /** Current set of OAuth 2.0 tokens. */
+  tokens: AuthTokens;
+  /** Actions for controlling the authentication lifecycle. */
+  actions: AuthActions;
+}

--- a/packages/preact/tsconfig.json
+++ b/packages/preact/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact"
+  },
+  "include": ["src"]
+}

--- a/packages/preact/tsconfig.typedoc.json
+++ b/packages/preact/tsconfig.typedoc.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false
+  }
+}

--- a/packages/preact/vite.config.ts
+++ b/packages/preact/vite.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vite";
+import preact from "@preact/preset-vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  plugins: [preact(), dts({ rollupTypes: true })],
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      formats: ["es", "cjs"],
+      fileName: (format) => `index.${format === "es" ? "js" : "cjs"}`,
+    },
+    sourcemap: true,
+    rollupOptions: {
+      external: [
+        "preact",
+        "preact/hooks",
+        "preact/jsx-runtime",
+        "preact/compat",
+        "oidc-js",
+        "oidc-js-core",
+      ],
+    },
+  },
+  test: {
+    environment: "jsdom",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,6 +132,34 @@ importers:
         specifier: ^4.0.0
         version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.6.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
 
+  packages/preact:
+    dependencies:
+      oidc-js:
+        specifier: workspace:*
+        version: link:../client
+      oidc-js-core:
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@preact/preset-vite':
+        specifier: ^2.9.0
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
+      preact:
+        specifier: ^10.0.0
+        version: 10.29.1
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)
+      vite-plugin-dts:
+        specifier: ^4.0.0
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
+
   packages/react:
     dependencies:
       oidc-js:
@@ -180,13 +208,13 @@ importers:
         version: 1.9.12
       typescript:
         specifier: ^5.5.0
-        version: 5.9.3
+        version: 5.6.3
       vite:
         specifier: ^8.0.0
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)
       vite-plugin-dts:
         specifier: ^4.0.0
-        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.9.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.6.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
       vite-plugin-solid:
         specifier: ^2.11.0
         version: 2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
@@ -318,6 +346,31 @@ importers:
         specifier: ^8.0.0
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)
 
+  tests/e2e/preact-app:
+    dependencies:
+      oidc-js-core:
+        specifier: workspace:*
+        version: link:../../../packages/core
+      oidc-js-preact:
+        specifier: workspace:*
+        version: link:../../../packages/preact
+      preact:
+        specifier: ^10.0.0
+        version: 10.29.1
+      preact-router:
+        specifier: ^4.1.0
+        version: 4.1.2(preact@10.29.1)
+    devDependencies:
+      '@preact/preset-vite':
+        specifier: ^2.9.0
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)
+
   tests/e2e/react-app:
     dependencies:
       oidc-js-core:
@@ -369,7 +422,7 @@ importers:
     devDependencies:
       typescript:
         specifier: ^5.5.0
-        version: 5.9.3
+        version: 5.6.3
       vite:
         specifier: ^8.0.0
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)
@@ -599,6 +652,10 @@ packages:
     resolution: {integrity: sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-annotate-as-pure@7.27.3':
+    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
@@ -662,6 +719,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-development@7.27.1':
+    resolution: {integrity: sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
@@ -670,6 +733,12 @@ packages:
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx@7.28.6':
+    resolution: {integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2045,6 +2114,29 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@preact/preset-vite@2.10.5':
+    resolution: {integrity: sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw==}
+    peerDependencies:
+      '@babel/core': 7.x
+      vite: 2.x || 3.x || 4.x || 5.x || 6.x || 7.x || 8.x
+
+  '@prefresh/babel-plugin@0.5.3':
+    resolution: {integrity: sha512-57LX2SHs4BX2s1IwCjNzTE2OJeEepRCNf1VTEpbNcUyHfMO68eeOWGDIt4ob9aYlW6PEWZ1SuwNikuoIXANDtQ==}
+
+  '@prefresh/core@1.5.9':
+    resolution: {integrity: sha512-IKBKCPaz34OFVC+adiQ2qaTF5qdztO2/4ZPf4KsRTgjKosWqxVXmEbxCiUydYZRY8GVie+DQlKzQr9gt6HQ+EQ==}
+    peerDependencies:
+      preact: ^10.0.0 || ^11.0.0-0
+
+  '@prefresh/utils@1.2.1':
+    resolution: {integrity: sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw==}
+
+  '@prefresh/vite@2.4.12':
+    resolution: {integrity: sha512-FY1fzXpUjiuosznMV0YM7XAOPZjB5FIdWS0W24+XnlxYkt9hNAwwsiKYn+cuTEoMtD/ZVazS5QVssBr9YhpCQA==}
+    peerDependencies:
+      preact: ^10.4.0 || ^11.0.0-0
+      vite: '>=2.0.0'
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2148,6 +2240,10 @@ packages:
 
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
+  '@rollup/pluginutils@4.2.1':
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -3041,6 +3137,11 @@ packages:
     resolution: {integrity: sha512-v3P1MW46Lm7VMpAkq0QfyzLWWkC8fh+0aE5Km4msIgDx5kjenHU0pF2s+4/NH8CQn/kla6+Hvws+2AF7bfV5qQ==}
     peerDependencies:
       '@babel/core': ^7.20.12
+
+  babel-plugin-transform-hook-names@1.0.2:
+    resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
+    peerDependencies:
+      '@babel/core': ^7.12.10
 
   babel-preset-solid@1.9.12:
     resolution: {integrity: sha512-LLqnuKVDlKpyBlMPcH6qEvs/wmS9a+NczppxJ3ryS/c0O5IiSFOIBQi9GzyiGDSbcJpx4Gr87jyFTos1MyEuWg==}
@@ -4718,6 +4819,9 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
@@ -4934,6 +5038,14 @@ packages:
   postcss@8.5.13:
     resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-router@4.1.2:
+    resolution: {integrity: sha512-uICUaUFYh+XQ+6vZtQn1q+X6rSqwq+zorWOCLWPF5FAsQh3EJ+RsDQ9Ee+fjk545YWQHfUxhrBAaemfxEnMOUg==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.29.1:
+    resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -5249,6 +5361,9 @@ packages:
     resolution: {integrity: sha512-ZpzWAFHIFqyFE56dXqgX/DkDRZdz+rRcjoIk/RQU4IX0wiCv1l8S7ZrXDHcCc+uaf+6o7w3h2l3g6GYG5TKN9Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  simple-code-frame@1.3.0:
+    resolution: {integrity: sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -5329,6 +5444,10 @@ packages:
   ssri@12.0.0:
     resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  stack-trace@1.0.0-pre2:
+    resolution: {integrity: sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==}
+    engines: {node: '>=16'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -5715,6 +5834,11 @@ packages:
     peerDependenciesMeta:
       '@testing-library/jest-dom':
         optional: true
+
+  vite-prerender-plugin@0.5.13:
+    resolution: {integrity: sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==}
+    peerDependencies:
+      vite: 5.x || 6.x || 7.x || 8.x
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -6402,6 +6526,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/helper-annotate-as-pure@7.27.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
       '@babel/compat-data': 7.29.3
@@ -6481,6 +6609,13 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -6490,6 +6625,17 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/runtime@7.29.2': {}
 
@@ -7542,6 +7688,45 @@ snapshots:
     dependencies:
       playwright: 1.59.1
 
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
+      '@prefresh/vite': 2.4.12(preact@10.29.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
+      debug: 4.4.3
+      magic-string: 0.30.21
+      picocolors: 1.1.1
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)
+      vite-prerender-plugin: 0.5.13(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - preact
+      - rollup
+      - supports-color
+
+  '@prefresh/babel-plugin@0.5.3': {}
+
+  '@prefresh/core@1.5.9(preact@10.29.1)':
+    dependencies:
+      preact: 10.29.1
+
+  '@prefresh/utils@1.2.1': {}
+
+  '@prefresh/vite@2.4.12(preact@10.29.1)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@prefresh/babel-plugin': 0.5.3
+      '@prefresh/core': 1.5.9(preact@10.29.1)
+      '@prefresh/utils': 1.2.1
+      '@rollup/pluginutils': 4.2.1
+      preact: 10.29.1
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
@@ -7596,6 +7781,11 @@ snapshots:
   '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
+
+  '@rollup/pluginutils@4.2.1':
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 2.3.2
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
     dependencies:
@@ -8601,6 +8791,10 @@ snapshots:
       '@babel/types': 7.29.0
       html-entities: 2.3.3
       parse5: 7.3.0
+
+  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
 
   babel-preset-solid@1.9.12(@babel/core@7.29.0)(solid-js@1.9.12):
     dependencies:
@@ -10785,6 +10979,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
+
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.38: {}
@@ -11055,6 +11254,12 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-router@4.1.2(preact@10.29.1):
+    dependencies:
+      preact: 10.29.1
+
+  preact@10.29.1: {}
 
   prelude-ls@1.2.1: {}
 
@@ -11524,6 +11729,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  simple-code-frame@1.3.0:
+    dependencies:
+      kolorist: 1.8.0
+
   sisteransi@1.0.5: {}
 
   sitemap@9.0.1:
@@ -11609,6 +11818,8 @@ snapshots:
   ssri@12.0.0:
     dependencies:
       minipass: 7.1.3
+
+  stack-trace@1.0.0-pre2: {}
 
   stackback@0.0.2: {}
 
@@ -12010,6 +12221,16 @@ snapshots:
       vitefu: 1.1.3(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
+
+  vite-prerender-plugin@0.5.13(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)):
+    dependencies:
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      node-html-parser: 6.1.13
+      simple-code-frame: 1.3.0
+      source-map: 0.7.6
+      stack-trace: 1.0.0-pre2
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)
 
   vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(sass@1.85.0)(yaml@2.8.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,5 @@ packages:
   - "tests/e2e/vue-app"
   - "tests/e2e/angular-app"
   - "tests/e2e/solid-app"
+  - "tests/e2e/preact-app"
   - "docs-web"

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -9,6 +9,7 @@
     "test:vue": "playwright test --config=playwright.vue.config.ts",
     "test:angular": "playwright test --config=playwright.angular.config.ts",
     "test:solid": "playwright test --config playwright.solid.config.ts",
+    "test:preact": "playwright test --config playwright.preact.config.ts",
     "test:ui": "playwright test --ui",
     "test:stress": "npx playwright test --repeat-each=100"
   },

--- a/tests/e2e/playwright.preact.config.ts
+++ b/tests/e2e/playwright.preact.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./specs",
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+  globalSetup: "./global-setup.ts",
+  globalTeardown: "./global-teardown.ts",
+  webServer: {
+    command: "pnpm --dir preact-app dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 15_000,
+  },
+});

--- a/tests/e2e/preact-app/index.html
+++ b/tests/e2e/preact-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OIDC E2E Test App (Preact)</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/tests/e2e/preact-app/package.json
+++ b/tests/e2e/preact-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "e2e-preact-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "dependencies": {
+    "oidc-js-core": "workspace:*",
+    "oidc-js-preact": "workspace:*",
+    "preact": "^10.0.0",
+    "preact-router": "^4.1.0"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "^2.9.0",
+    "typescript": "^5.5.0",
+    "vite": "^8.0.0"
+  }
+}

--- a/tests/e2e/preact-app/src/App.tsx
+++ b/tests/e2e/preact-app/src/App.tsx
@@ -1,0 +1,16 @@
+import Router from "preact-router";
+import { HomePage } from "./pages/Home.js";
+import { CallbackPage } from "./pages/Callback.js";
+import { ProtectedA } from "./pages/ProtectedA.js";
+import { ProtectedB } from "./pages/ProtectedB.js";
+
+export function App() {
+  return (
+    <Router>
+      <HomePage path="/" />
+      <CallbackPage path="/callback" />
+      <ProtectedA path="/protected-a" />
+      <ProtectedB path="/protected-b" />
+    </Router>
+  );
+}

--- a/tests/e2e/preact-app/src/index.tsx
+++ b/tests/e2e/preact-app/src/index.tsx
@@ -1,0 +1,29 @@
+import { render } from "preact";
+import { AuthProvider } from "oidc-js-preact";
+import { route } from "preact-router";
+import { useCallback } from "preact/hooks";
+import { App } from "./App.js";
+
+const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+
+const config = {
+  issuer: "http://localhost:9999/oauth2",
+  clientId: "e2e-test-app",
+  redirectUri: "http://localhost:5173/callback",
+  scopes: ["openid", "profile", "email", "offline_access"],
+  postLogoutRedirectUri: "http://localhost:5173",
+};
+
+function Root() {
+  const onLogin = useCallback((returnTo: string) => {
+    route(returnTo, true);
+  }, []);
+
+  return (
+    <AuthProvider config={config} fetchProfile={fetchProfile} onLogin={onLogin}>
+      <App />
+    </AuthProvider>
+  );
+}
+
+render(<Root />, document.getElementById("root")!);

--- a/tests/e2e/preact-app/src/pages/Callback.tsx
+++ b/tests/e2e/preact-app/src/pages/Callback.tsx
@@ -1,0 +1,7 @@
+interface CallbackPageProps {
+  path?: string;
+}
+
+export function CallbackPage(_props: CallbackPageProps) {
+  return <div data-testid="auth-loading">Processing login...</div>;
+}

--- a/tests/e2e/preact-app/src/pages/Home.tsx
+++ b/tests/e2e/preact-app/src/pages/Home.tsx
@@ -1,0 +1,57 @@
+import { useAuth } from "oidc-js-preact";
+
+interface HomePageProps {
+  path?: string;
+}
+
+export function HomePage(_props: HomePageProps) {
+  const { user, isAuthenticated, isLoading, error, tokens, actions } = useAuth();
+
+  if (isLoading) {
+    return <div data-testid="auth-loading">Loading...</div>;
+  }
+
+  if (error) {
+    return <div data-testid="auth-error">Error: {error.message}</div>;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div data-testid="unauthenticated">
+        <h1>Not logged in</h1>
+        <button data-testid="login-button" onClick={() => actions.login()}>
+          Login
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="authenticated">
+      <h1>Logged in</h1>
+      <div data-testid="user-sub">{user?.claims.sub}</div>
+      <div data-testid="user-iss">{user?.claims.iss}</div>
+      <div data-testid="user-aud">{typeof user?.claims.aud === "string" ? user.claims.aud : JSON.stringify(user?.claims.aud)}</div>
+      <div data-testid="user-exp">{user?.claims.exp}</div>
+      <div data-testid="user-iat">{user?.claims.iat}</div>
+      <div data-testid="user-email">{user?.profile?.email ?? "no profile"}</div>
+      <div data-testid="user-profile-null">{user?.profile === null ? "true" : "false"}</div>
+      <div data-testid="access-token">{tokens.access ? "present" : "missing"}</div>
+      <div data-testid="refresh-token">{tokens.refresh ? "present" : "missing"}</div>
+      <div data-testid="access-token-value" style={{ display: "none" }}>{tokens.access ?? ""}</div>
+      <div data-testid="refresh-token-value" style={{ display: "none" }}>{tokens.refresh ?? ""}</div>
+      <div data-testid="id-token">{tokens.id ? "present" : "missing"}</div>
+      <div data-testid="expires-at">{tokens.expiresAt ?? "none"}</div>
+      <button data-testid="logout-button" onClick={() => actions.logout()}>
+        Logout
+      </button>
+      <button data-testid="refresh-button" onClick={() => actions.refresh().catch(() => {})}>
+        Refresh
+      </button>
+      <nav>
+        <a data-testid="link-protected-a" href="/protected-a">Protected A</a>
+        <a data-testid="link-protected-b" href="/protected-b">Protected B</a>
+      </nav>
+    </div>
+  );
+}

--- a/tests/e2e/preact-app/src/pages/ProtectedA.tsx
+++ b/tests/e2e/preact-app/src/pages/ProtectedA.tsx
@@ -1,0 +1,20 @@
+import { RequireAuth } from "oidc-js-preact";
+
+interface ProtectedAProps {
+  path?: string;
+}
+
+export function ProtectedA(_props: ProtectedAProps) {
+  return (
+    <RequireAuth fallback={<div data-testid="auth-loading">Refreshing...</div>}>
+      <div data-testid="protected-a">
+        Protected content A
+      </div>
+      <nav>
+        <a data-testid="link-home" href="/">Home</a>
+        <a data-testid="link-protected-a" href="/protected-a">Protected A</a>
+        <a data-testid="link-protected-b" href="/protected-b">Protected B</a>
+      </nav>
+    </RequireAuth>
+  );
+}

--- a/tests/e2e/preact-app/src/pages/ProtectedB.tsx
+++ b/tests/e2e/preact-app/src/pages/ProtectedB.tsx
@@ -1,0 +1,20 @@
+import { RequireAuth } from "oidc-js-preact";
+
+interface ProtectedBProps {
+  path?: string;
+}
+
+export function ProtectedB(_props: ProtectedBProps) {
+  return (
+    <RequireAuth fallback={<div data-testid="auth-loading">Refreshing...</div>}>
+      <div data-testid="protected-b">
+        Protected content B
+      </div>
+      <nav>
+        <a data-testid="link-home" href="/">Home</a>
+        <a data-testid="link-protected-a" href="/protected-a">Protected A</a>
+        <a data-testid="link-protected-b" href="/protected-b">Protected B</a>
+      </nav>
+    </RequireAuth>
+  );
+}

--- a/tests/e2e/preact-app/tsconfig.json
+++ b/tests/e2e/preact-app/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src"]
+}

--- a/tests/e2e/preact-app/vite.config.ts
+++ b/tests/e2e/preact-app/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import preact from "@preact/preset-vite";
+
+export default defineConfig({
+  plugins: [preact()],
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `packages/preact/` (`oidc-js-preact`) mirroring the React adapter API
- `AuthProvider`, `useAuth()`, `RequireAuth` using Preact hooks
- E2E test app at `tests/e2e/preact-app/` with full data-testid contract
- Playwright config and test script wired up

## Test plan
- [ ] `pnpm --filter oidc-js-preact build` passes
- [ ] `pnpm --filter e2e-tests test:preact` passes
- [ ] All shared E2E specs pass against Preact test app

🤖 Generated with [Claude Code](https://claude.com/claude-code)