### PR TITLE
feat: add oidc-js-kasper adapter

### DIFF
--- a/decisions.md
+++ b/decisions.md
@@ -278,7 +278,19 @@ Architectural and design decisions for the oidc-js project. Each entry captures 
 
 **Rationale**: Fetch requests and full-page navigations are fundamentally different — mixing them creates race condition risks since a navigation triggers multiple events (request, response, `framenavigated`). Separate tracking makes assertions clear: `LOGIN_REQUESTS` for protocol calls, `LOGIN_NAVIGATIONS` for redirects. Constants like `DISCOVERY` and `LOGIN_REQUESTS` keep assertions DRY across tests.
 
-### 024 - Defer Ember adapter, ship 7 frameworks (2026-05-01)
+### 024 - Atomic state updates via framework batching, not single-object signal (2026-05-02)
+
+**Context**: All framework adapters store auth state as separate reactive primitives (one signal/store/ref per field: `user`, `isAuthenticated`, `isLoading`, `error`, `tokens`). The Kasper adapter exposed a tearing bug: writing five signals sequentially without `batch()` caused effects to fire between writes, seeing inconsistent intermediate state. This triggered a logout→login race and a double-navigation bug.
+
+**Alternatives considered**:
+1. Single state object signal — one write, one effect flush, no tearing possible
+2. Separate signals with `batch()` to group writes atomically
+
+**Decision**: Option 2 across all adapters. Kasper explicitly uses `batch()` in its subscriber. Other frameworks handle this implicitly (React 18+ auto-batches, Solid batches within effects, Svelte 5 batches rune updates).
+
+**Rationale**: A single object signal eliminates tearing by design but sacrifices granularity — every state change notifies all consumers. For auth state (changes 2-3 times per session), the granularity win is negligible and wasn't worth the added complexity of the fix. However, separate signals map naturally to each framework's idiomatic reactivity primitive and preserve fine-grained updates for frameworks where it matters (Solid, Svelte). The real lesson: when bridging a subscribe-based state source into a signal system, always batch the writes. This is not Kasper-specific — any framework with synchronous or microtask-flushed effects needs atomic grouped updates from external state sources.
+
+### 025 - Defer Ember adapter, ship 7 frameworks (2026-05-01)
 
 **Context**: Built framework adapters for Vue, Svelte, Angular, Solid, Preact, and Lit. An Ember Octane adapter was also built and has a working E2E test app, but the PR adds ~10k lines due to Ember's lockfile and build tooling.
 

--- a/packages/kasper/package.json
+++ b/packages/kasper/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "oidc-js-kasper",
+  "version": "1.0.0",
+  "description": "Simple OIDC authentication for Kasper.js. Signals, components, and auth guards with zero dependencies.",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "lint": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "oidc-js": "workspace:*",
+    "oidc-js-core": "workspace:*"
+  },
+  "peerDependencies": {
+    "kasper-js": ">=0.3.25"
+  },
+  "devDependencies": {
+    "kasper-js": "^0.3.25",
+    "typescript": "^5.5.0",
+    "vite": "^8.0.0",
+    "vite-plugin-dts": "^4.0.0",
+    "vitest": "^4.0.0",
+    "jsdom": "^26.0.0"
+  },
+  "keywords": [
+    "oidc",
+    "openid-connect",
+    "oauth2",
+    "authentication",
+    "kasper",
+    "kasper-js",
+    "signals"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eugenioenko/oidc-js.git",
+    "directory": "packages/kasper"
+  },
+  "homepage": "https://eugenioenko.github.io/oidc-js/"
+}

--- a/packages/kasper/src/auth-provider.ts
+++ b/packages/kasper/src/auth-provider.ts
@@ -1,0 +1,58 @@
+import { Component } from "kasper-js";
+import type { OidcConfig } from "oidc-js-core";
+import type { OidcClient } from "oidc-js";
+import { _initAuth, _destroyAuth } from "./context.js";
+
+interface AuthProviderArgs {
+  config: OidcConfig;
+  fetchProfile?: boolean;
+  onLogin?: (returnTo: string) => void;
+  onError?: (error: Error) => void;
+}
+
+/**
+ * Wraps the application and provides OIDC authentication state.
+ * Register as a tag in the Kasper registry and pass config via args.
+ *
+ * @example
+ * ```html
+ * <auth-provider @:config="config" @:onLogin="handleLogin">
+ *   <app-content />
+ * </auth-provider>
+ * ```
+ */
+export class AuthProvider extends Component<AuthProviderArgs> {
+  static template = "<slot />";
+
+  private _unsub: (() => void) | null = null;
+  private _client: OidcClient | null = null;
+
+  onMount(): void {
+    const config = this.args.config;
+    const fetchProfile = this.args.fetchProfile ?? true;
+    const onLogin = this.args.onLogin;
+    const onError = this.args.onError;
+
+    const { client, unsub } = _initAuth(config, fetchProfile);
+    this._client = client;
+    this._unsub = unsub;
+
+    client.init().then(({ returnTo }) => {
+      const s = client.state;
+      if (s.error && onError) onError(s.error);
+      if (returnTo) {
+        if (onLogin) {
+          onLogin(returnTo);
+        } else {
+          window.history.replaceState({}, "", returnTo);
+        }
+      }
+    });
+  }
+
+  onDestroy(): void {
+    this._unsub?.();
+    this._client?.destroy();
+    _destroyAuth();
+  }
+}

--- a/packages/kasper/src/context.ts
+++ b/packages/kasper/src/context.ts
@@ -1,0 +1,91 @@
+import { signal, batch } from "kasper-js";
+import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
+import type { OidcConfig } from "oidc-js-core";
+import type { AuthContextValue, AuthActions } from "./types.js";
+
+const _user = signal<AuthState["user"]>(null);
+const _isAuthenticated = signal(false);
+const _isLoading = signal(true);
+const _error = signal<AuthState["error"]>(null);
+const _tokens = signal<AuthState["tokens"]>({
+  access: null,
+  id: null,
+  refresh: null,
+  expiresAt: null,
+});
+
+let _client: OidcClient | null = null;
+let _config: OidcConfig | null = null;
+let _actions: AuthActions | null = null;
+let _unsub: (() => void) | null = null;
+
+/** @internal */
+export function _initAuth(
+  config: OidcConfig,
+  fetchProfile: boolean,
+): { client: OidcClient; unsub: () => void } {
+  const client = new OidcClient({ ...config, fetchProfile });
+  _client = client;
+  _config = config;
+  _actions = {
+    login: (options?: LoginOptions) => {
+      client.login(options);
+    },
+    logout: () => {
+      // Unsubscribe before logout to prevent RequireAuth from reacting
+      // to the intermediate unauthenticated state and racing with the
+      // logout redirect by triggering a login redirect.
+      _unsub?.();
+      client.logout();
+    },
+    refresh: () => client.refresh(),
+    fetchProfile: () => client.fetchProfile(),
+  };
+
+  const unsub = client.subscribe((state: AuthState) => {
+    batch(() => {
+      _user.value = state.user;
+      _isAuthenticated.value = state.isAuthenticated;
+      _isLoading.value = state.isLoading;
+      _error.value = state.error;
+      _tokens.value = state.tokens;
+    });
+  });
+  _unsub = unsub;
+
+  return { client, unsub };
+}
+
+/** @internal */
+export function _destroyAuth(): void {
+  _client = null;
+  _config = null;
+  _actions = null;
+  _user.value = null;
+  _isAuthenticated.value = false;
+  _isLoading.value = true;
+  _error.value = null;
+  _tokens.value = { access: null, id: null, refresh: null, expiresAt: null };
+}
+
+/**
+ * Returns the current authentication state and actions.
+ * Must be called in a component rendered inside an AuthProvider.
+ *
+ * @returns Reactive auth state (Kasper signals) and actions.
+ * @throws If called before AuthProvider has mounted.
+ */
+export function useAuth(): AuthContextValue {
+  if (!_client || !_config || !_actions) {
+    throw new Error("useAuth must be used within an AuthProvider");
+  }
+  return {
+    config: _config,
+    user: _user,
+    isAuthenticated: _isAuthenticated,
+    isLoading: _isLoading,
+    error: _error,
+    tokens: _tokens,
+    actions: _actions,
+  };
+}

--- a/packages/kasper/src/index.ts
+++ b/packages/kasper/src/index.ts
@@ -1,0 +1,13 @@
+export { AuthProvider } from "./auth-provider.js";
+export { RequireAuth } from "./require-auth.js";
+export { useAuth } from "./context.js";
+export type {
+  IdTokenClaims,
+  AuthUser,
+  AuthTokens,
+  AuthActions,
+  AuthContextValue,
+  Signal,
+  LoginOptions,
+} from "./types.js";
+export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/kasper/src/require-auth.ts
+++ b/packages/kasper/src/require-auth.ts
@@ -1,0 +1,65 @@
+import { Component } from "kasper-js";
+import type { LoginOptions } from "oidc-js";
+import { useAuth } from "./context.js";
+
+interface RequireAuthArgs {
+  autoRefresh?: boolean;
+  loginOptions?: LoginOptions;
+}
+
+/**
+ * Guard component that only renders its default slot when the user is authenticated.
+ * Shows the "fallback" named slot while loading or redirecting.
+ *
+ * @example
+ * ```html
+ * <require-auth>
+ *   <div @slot="fallback">Loading...</div>
+ *   <protected-content />
+ * </require-auth>
+ * ```
+ */
+export class RequireAuth extends Component<RequireAuthArgs> {
+  static template =
+    '<span @if="!_ready()"><slot @name="fallback" /></span>' +
+    '<span @else><slot /></span>';
+
+  private _refreshAttempted = false;
+
+  _ready(): boolean {
+    const auth = useAuth();
+    const isExpired =
+      auth.tokens.value.expiresAt !== null &&
+      auth.tokens.value.expiresAt <= Date.now();
+    return (
+      !auth.isLoading.value && auth.isAuthenticated.value && !isExpired
+    );
+  }
+
+  onMount(): void {
+    const auth = useAuth();
+    const autoRefresh = this.args.autoRefresh ?? true;
+
+    this.effect(() => {
+      const isExpired =
+        auth.tokens.value.expiresAt !== null &&
+        auth.tokens.value.expiresAt <= Date.now();
+      const needsAuth = !auth.isAuthenticated.value || isExpired;
+
+      if (!needsAuth) {
+        this._refreshAttempted = false;
+        return;
+      }
+      if (auth.isLoading.value) return;
+
+      if (autoRefresh && !this._refreshAttempted) {
+        this._refreshAttempted = true;
+        auth.actions
+          .refresh()
+          .catch(() => auth.actions.login(this.args.loginOptions));
+        return;
+      }
+      auth.actions.login(this.args.loginOptions);
+    });
+  }
+}

--- a/packages/kasper/src/tests/auth-provider.test.ts
+++ b/packages/kasper/src/tests/auth-provider.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { OidcConfig } from "oidc-js-core";
+
+const mockClientInstance = {
+  subscribe: vi.fn((_cb: (state: unknown) => void) => vi.fn()),
+  init: vi.fn().mockResolvedValue({ returnTo: undefined }),
+  login: vi.fn(),
+  logout: vi.fn(),
+  refresh: vi.fn().mockResolvedValue(undefined),
+  fetchProfile: vi.fn().mockResolvedValue(undefined),
+  destroy: vi.fn(),
+  state: {
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    error: null,
+    tokens: { access: null, id: null, refresh: null, expiresAt: null },
+  },
+};
+
+vi.mock("oidc-js", () => ({
+  OidcClient: vi.fn().mockImplementation(function () {
+    return mockClientInstance;
+  }),
+}));
+
+import { AuthProvider } from "../auth-provider.js";
+import { _destroyAuth, useAuth } from "../context.js";
+
+const CONFIG: OidcConfig = {
+  issuer: "https://auth.example.com",
+  clientId: "my-app",
+  redirectUri: "http://localhost:3000/callback",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _destroyAuth();
+  vi.spyOn(window.history, "replaceState").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  _destroyAuth();
+  vi.restoreAllMocks();
+});
+
+interface AuthProviderArgs {
+  config: OidcConfig;
+  fetchProfile?: boolean;
+  onLogin?: (returnTo: string) => void;
+  onError?: (error: Error) => void;
+}
+
+function createProvider(args: AuthProviderArgs): AuthProvider {
+  return new AuthProvider({ args } as never);
+}
+
+describe("AuthProvider", () => {
+  it("initializes auth context on mount", () => {
+    const provider = createProvider({ config: CONFIG });
+    provider.onMount();
+
+    const auth = useAuth();
+    expect(auth.config).toEqual(CONFIG);
+  });
+
+  it("calls client.init() on mount", () => {
+    const provider = createProvider({ config: CONFIG });
+    provider.onMount();
+
+    expect(mockClientInstance.init).toHaveBeenCalled();
+  });
+
+  it("defaults fetchProfile to true", async () => {
+    const { OidcClient } =
+      await vi.importMock<typeof import("oidc-js")>("oidc-js");
+
+    const provider = createProvider({ config: CONFIG });
+    provider.onMount();
+
+    expect(OidcClient).toHaveBeenCalledWith({ ...CONFIG, fetchProfile: true });
+  });
+
+  it("passes fetchProfile=false when configured", async () => {
+    const { OidcClient } =
+      await vi.importMock<typeof import("oidc-js")>("oidc-js");
+
+    const provider = createProvider({
+      config: CONFIG,
+      fetchProfile: false,
+    });
+    provider.onMount();
+
+    expect(OidcClient).toHaveBeenCalledWith({ ...CONFIG, fetchProfile: false });
+  });
+
+  it("calls onLogin callback with returnTo after init", async () => {
+    mockClientInstance.init.mockResolvedValueOnce({ returnTo: "/dashboard" });
+    const onLogin = vi.fn();
+
+    const provider = createProvider({ config: CONFIG, onLogin });
+    provider.onMount();
+
+    await vi.waitFor(() => {
+      expect(onLogin).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("defaults to history.replaceState when no onLogin", async () => {
+    mockClientInstance.init.mockResolvedValueOnce({ returnTo: "/dashboard" });
+
+    const provider = createProvider({ config: CONFIG });
+    provider.onMount();
+
+    await vi.waitFor(() => {
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        {},
+        "",
+        "/dashboard",
+      );
+    });
+  });
+
+  it("does not call onLogin when returnTo is undefined", async () => {
+    mockClientInstance.init.mockResolvedValueOnce({ returnTo: undefined });
+    const onLogin = vi.fn();
+
+    const provider = createProvider({ config: CONFIG, onLogin });
+    provider.onMount();
+
+    await vi.waitFor(() => {
+      expect(mockClientInstance.init).toHaveBeenCalled();
+    });
+
+    expect(onLogin).not.toHaveBeenCalled();
+  });
+
+  it("calls onError when init results in error state", async () => {
+    const error = new Error("discovery failed");
+    mockClientInstance.init.mockResolvedValueOnce({ returnTo: undefined });
+    const origState = mockClientInstance.state;
+    mockClientInstance.state = { ...origState, error } as unknown as typeof origState;
+    const onError = vi.fn();
+
+    const provider = createProvider({ config: CONFIG, onError });
+    provider.onMount();
+
+    await vi.waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(error);
+    });
+
+    mockClientInstance.state = origState;
+  });
+
+  it("cleans up on destroy", () => {
+    const unsubFn = vi.fn();
+    mockClientInstance.subscribe.mockReturnValueOnce(unsubFn);
+
+    const provider = createProvider({ config: CONFIG });
+    provider.onMount();
+    provider.onDestroy();
+
+    expect(unsubFn).toHaveBeenCalled();
+    expect(mockClientInstance.destroy).toHaveBeenCalled();
+    expect(() => useAuth()).toThrow(
+      "useAuth must be used within an AuthProvider",
+    );
+  });
+});

--- a/packages/kasper/src/tests/context.test.ts
+++ b/packages/kasper/src/tests/context.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { OidcConfig } from "oidc-js-core";
+
+const mockClientInstance = {
+  subscribe: vi.fn((_cb: (state: unknown) => void) => {
+    return vi.fn();
+  }),
+  init: vi.fn().mockResolvedValue({ returnTo: undefined }),
+  login: vi.fn(),
+  logout: vi.fn(),
+  refresh: vi.fn().mockResolvedValue(undefined),
+  fetchProfile: vi.fn().mockResolvedValue(undefined),
+  destroy: vi.fn(),
+  state: {
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    error: null,
+    tokens: { access: null, id: null, refresh: null, expiresAt: null },
+  },
+};
+
+vi.mock("oidc-js", () => ({
+  OidcClient: vi.fn().mockImplementation(function () {
+    return mockClientInstance;
+  }),
+}));
+
+import { _initAuth, _destroyAuth, useAuth } from "../context.js";
+
+const CONFIG: OidcConfig = {
+  issuer: "https://auth.example.com",
+  clientId: "my-app",
+  redirectUri: "http://localhost:3000/callback",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _destroyAuth();
+});
+
+afterEach(() => {
+  _destroyAuth();
+  vi.restoreAllMocks();
+});
+
+describe("useAuth", () => {
+  it("throws when called before _initAuth", () => {
+    expect(() => useAuth()).toThrow(
+      "useAuth must be used within an AuthProvider",
+    );
+  });
+
+  it("returns auth context after _initAuth", () => {
+    _initAuth(CONFIG, true);
+    const auth = useAuth();
+
+    expect(auth.config).toEqual(CONFIG);
+    expect(auth.user.value).toBeNull();
+    expect(auth.isAuthenticated.value).toBe(false);
+    expect(auth.isLoading.value).toBe(true);
+    expect(auth.error.value).toBeNull();
+    expect(auth.tokens.value).toEqual({
+      access: null,
+      id: null,
+      refresh: null,
+      expiresAt: null,
+    });
+  });
+
+  it("exposes actions that delegate to OidcClient", () => {
+    _initAuth(CONFIG, true);
+    const auth = useAuth();
+
+    auth.actions.login();
+    expect(mockClientInstance.login).toHaveBeenCalled();
+
+    auth.actions.logout();
+    expect(mockClientInstance.logout).toHaveBeenCalled();
+
+    auth.actions.refresh();
+    expect(mockClientInstance.refresh).toHaveBeenCalled();
+
+    auth.actions.fetchProfile();
+    expect(mockClientInstance.fetchProfile).toHaveBeenCalled();
+  });
+});
+
+describe("_initAuth", () => {
+  it("creates OidcClient with config and fetchProfile", async () => {
+    const { OidcClient } = await vi.importMock<typeof import("oidc-js")>(
+      "oidc-js",
+    );
+
+    _initAuth(CONFIG, true);
+
+    expect(OidcClient).toHaveBeenCalledWith({ ...CONFIG, fetchProfile: true });
+  });
+
+  it("returns client and unsub function", () => {
+    const result = _initAuth(CONFIG, false);
+
+    expect(result.client).toBe(mockClientInstance);
+    expect(typeof result.unsub).toBe("function");
+  });
+
+  it("subscribes to client state changes", () => {
+    _initAuth(CONFIG, true);
+
+    expect(mockClientInstance.subscribe).toHaveBeenCalledWith(
+      expect.any(Function),
+    );
+  });
+
+  it("updates signals when subscriber fires", () => {
+    _initAuth(CONFIG, true);
+    const subscriber = mockClientInstance.subscribe.mock.calls[0][0];
+
+    subscriber({
+      user: { claims: { sub: "user-1" }, profile: null },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      tokens: { access: "at_123", id: "id_456", refresh: "rt_789", expiresAt: 9999999999999 },
+    });
+
+    const auth = useAuth();
+    expect(auth.isAuthenticated.value).toBe(true);
+    expect(auth.isLoading.value).toBe(false);
+    expect(auth.user.value?.claims.sub).toBe("user-1");
+    expect(auth.tokens.value.access).toBe("at_123");
+  });
+});
+
+describe("_destroyAuth", () => {
+  it("resets all signals to initial values", () => {
+    _initAuth(CONFIG, true);
+    const subscriber = mockClientInstance.subscribe.mock.calls[0][0];
+
+    subscriber({
+      user: { claims: { sub: "user-1" }, profile: null },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      tokens: { access: "at_123", id: null, refresh: null, expiresAt: null },
+    });
+
+    _destroyAuth();
+
+    expect(() => useAuth()).toThrow(
+      "useAuth must be used within an AuthProvider",
+    );
+  });
+});
+
+describe("logout unsubscribes before calling client", () => {
+  it("unsubscribes from state changes before logout redirect", () => {
+    const unsubFn = vi.fn();
+    mockClientInstance.subscribe.mockReturnValueOnce(unsubFn);
+
+    _initAuth(CONFIG, true);
+    const auth = useAuth();
+
+    auth.actions.logout();
+
+    expect(unsubFn).toHaveBeenCalled();
+    expect(mockClientInstance.logout).toHaveBeenCalled();
+
+    const unsubOrder = unsubFn.mock.invocationCallOrder[0];
+    const logoutOrder = mockClientInstance.logout.mock.invocationCallOrder[0];
+    expect(unsubOrder).toBeLessThan(logoutOrder);
+  });
+});

--- a/packages/kasper/src/tests/require-auth.test.ts
+++ b/packages/kasper/src/tests/require-auth.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { AuthContextValue } from "../types.js";
+
+type MutableAuth = { -readonly [K in keyof AuthContextValue]: AuthContextValue[K] };
+
+const mockAuth: MutableAuth = {
+  config: { issuer: "https://auth.example.com", clientId: "app" },
+  user: { value: null } as AuthContextValue["user"],
+  isAuthenticated: { value: false } as AuthContextValue["isAuthenticated"],
+  isLoading: { value: false } as AuthContextValue["isLoading"],
+  error: { value: null } as AuthContextValue["error"],
+  tokens: {
+    value: { access: null, id: null, refresh: null, expiresAt: null },
+  } as AuthContextValue["tokens"],
+  actions: {
+    login: vi.fn(),
+    logout: vi.fn(),
+    refresh: vi.fn().mockRejectedValue(new Error("No refresh token")),
+    fetchProfile: vi.fn(),
+  },
+};
+
+vi.mock("../context.js", () => ({
+  useAuth: () => mockAuth,
+}));
+
+import { RequireAuth } from "../require-auth.js";
+
+interface RequireAuthArgs {
+  autoRefresh?: boolean;
+  loginOptions?: Record<string, string>;
+}
+
+let capturedEffects: Array<() => void> = [];
+
+function createRequireAuth(args: RequireAuthArgs = {}): RequireAuth {
+  const instance = new RequireAuth({ args } as never);
+  const origEffect = instance.effect.bind(instance);
+  instance.effect = (fn: () => void) => {
+    capturedEffects.push(fn);
+    origEffect(fn);
+  };
+  return instance;
+}
+
+function resetAuth(overrides: Partial<MutableAuth> = {}) {
+  mockAuth.user = { value: null } as AuthContextValue["user"];
+  mockAuth.isAuthenticated = {
+    value: false,
+  } as AuthContextValue["isAuthenticated"];
+  mockAuth.isLoading = { value: false } as AuthContextValue["isLoading"];
+  mockAuth.error = { value: null } as AuthContextValue["error"];
+  mockAuth.tokens = {
+    value: { access: null, id: null, refresh: null, expiresAt: null },
+  } as AuthContextValue["tokens"];
+  mockAuth.actions = {
+    login: vi.fn(),
+    logout: vi.fn(),
+    refresh: vi.fn().mockRejectedValue(new Error("No refresh token")),
+    fetchProfile: vi.fn(),
+  };
+
+  if (overrides.isAuthenticated !== undefined)
+    mockAuth.isAuthenticated = overrides.isAuthenticated;
+  if (overrides.isLoading !== undefined)
+    mockAuth.isLoading = overrides.isLoading;
+  if (overrides.tokens !== undefined) mockAuth.tokens = overrides.tokens;
+  if (overrides.user !== undefined) mockAuth.user = overrides.user;
+  if (overrides.error !== undefined) mockAuth.error = overrides.error;
+  if (overrides.actions !== undefined) mockAuth.actions = overrides.actions;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedEffects = [];
+  resetAuth();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RequireAuth", () => {
+  describe("_ready()", () => {
+    it("returns true when authenticated with valid token", () => {
+      resetAuth({
+        isAuthenticated: { value: true } as AuthContextValue["isAuthenticated"],
+        isLoading: { value: false } as AuthContextValue["isLoading"],
+        tokens: {
+          value: {
+            access: "token",
+            id: null,
+            refresh: null,
+            expiresAt: Date.now() + 3600_000,
+          },
+        } as AuthContextValue["tokens"],
+      });
+
+      const guard = createRequireAuth();
+      expect(guard._ready()).toBe(true);
+    });
+
+    it("returns false when loading", () => {
+      resetAuth({
+        isLoading: { value: true } as AuthContextValue["isLoading"],
+      });
+
+      const guard = createRequireAuth();
+      expect(guard._ready()).toBe(false);
+    });
+
+    it("returns false when not authenticated", () => {
+      resetAuth({
+        isAuthenticated: {
+          value: false,
+        } as AuthContextValue["isAuthenticated"],
+      });
+
+      const guard = createRequireAuth();
+      expect(guard._ready()).toBe(false);
+    });
+
+    it("returns false when token is expired", () => {
+      resetAuth({
+        isAuthenticated: { value: true } as AuthContextValue["isAuthenticated"],
+        isLoading: { value: false } as AuthContextValue["isLoading"],
+        tokens: {
+          value: {
+            access: "expired",
+            id: null,
+            refresh: null,
+            expiresAt: Date.now() - 60_000,
+          },
+        } as AuthContextValue["tokens"],
+      });
+
+      const guard = createRequireAuth();
+      expect(guard._ready()).toBe(false);
+    });
+  });
+
+  describe("effect behavior", () => {
+    it("calls login when not authenticated and autoRefresh is false", () => {
+      const actions = {
+        login: vi.fn(),
+        logout: vi.fn(),
+        refresh: vi.fn().mockRejectedValue(new Error("no token")),
+        fetchProfile: vi.fn(),
+      };
+      resetAuth({ actions });
+
+      const guard = createRequireAuth({ autoRefresh: false });
+      guard.onMount();
+
+      expect(actions.login).toHaveBeenCalled();
+    });
+
+    it("attempts refresh before login when autoRefresh is true", async () => {
+      const actions = {
+        login: vi.fn(),
+        logout: vi.fn(),
+        refresh: vi.fn().mockRejectedValue(new Error("no token")),
+        fetchProfile: vi.fn(),
+      };
+      resetAuth({ actions });
+
+      const guard = createRequireAuth({ autoRefresh: true });
+      guard.onMount();
+
+      expect(actions.refresh).toHaveBeenCalled();
+
+      await vi.waitFor(() => {
+        expect(actions.login).toHaveBeenCalled();
+      });
+    });
+
+    it("does not call login when authenticated", () => {
+      const actions = {
+        login: vi.fn(),
+        logout: vi.fn(),
+        refresh: vi.fn(),
+        fetchProfile: vi.fn(),
+      };
+      resetAuth({
+        isAuthenticated: { value: true } as AuthContextValue["isAuthenticated"],
+        tokens: {
+          value: {
+            access: "token",
+            id: null,
+            refresh: null,
+            expiresAt: Date.now() + 3600_000,
+          },
+        } as AuthContextValue["tokens"],
+        actions,
+      });
+
+      const guard = createRequireAuth();
+      guard.onMount();
+
+      expect(actions.login).not.toHaveBeenCalled();
+      expect(actions.refresh).not.toHaveBeenCalled();
+    });
+
+    it("does not act while loading", () => {
+      const actions = {
+        login: vi.fn(),
+        logout: vi.fn(),
+        refresh: vi.fn(),
+        fetchProfile: vi.fn(),
+      };
+      resetAuth({
+        isLoading: { value: true } as AuthContextValue["isLoading"],
+        actions,
+      });
+
+      const guard = createRequireAuth();
+      guard.onMount();
+
+      expect(actions.login).not.toHaveBeenCalled();
+      expect(actions.refresh).not.toHaveBeenCalled();
+    });
+
+    it("triggers refresh when token is expired", () => {
+      const actions = {
+        login: vi.fn(),
+        logout: vi.fn(),
+        refresh: vi.fn().mockResolvedValue(undefined),
+        fetchProfile: vi.fn(),
+      };
+      resetAuth({
+        isAuthenticated: { value: true } as AuthContextValue["isAuthenticated"],
+        tokens: {
+          value: {
+            access: "expired",
+            id: null,
+            refresh: "rt",
+            expiresAt: Date.now() - 60_000,
+          },
+        } as AuthContextValue["tokens"],
+        actions,
+      });
+
+      const guard = createRequireAuth();
+      guard.onMount();
+
+      expect(actions.refresh).toHaveBeenCalled();
+    });
+
+    it("passes loginOptions to login action", () => {
+      const actions = {
+        login: vi.fn(),
+        logout: vi.fn(),
+        refresh: vi.fn().mockRejectedValue(new Error("no token")),
+        fetchProfile: vi.fn(),
+      };
+      resetAuth({ actions });
+
+      const loginOptions = { prompt: "login" };
+      const guard = createRequireAuth({
+        autoRefresh: false,
+        loginOptions,
+      });
+      guard.onMount();
+
+      expect(actions.login).toHaveBeenCalledWith(loginOptions);
+    });
+  });
+});

--- a/packages/kasper/src/types.ts
+++ b/packages/kasper/src/types.ts
@@ -1,0 +1,36 @@
+import type { Signal } from "kasper-js";
+import type { OidcConfig } from "oidc-js-core";
+import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+
+export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+export type { Signal } from "kasper-js";
+
+/** Actions available for controlling authentication flow. */
+export interface AuthActions {
+  /** Redirects the user to the OIDC provider's authorization endpoint. */
+  login: (options?: LoginOptions) => void;
+  /** Logs the user out and redirects to the post-logout URI. */
+  logout: () => void;
+  /** Refreshes the access token using the refresh token. */
+  refresh: () => Promise<void>;
+  /** Fetches the user's profile from the userinfo endpoint. */
+  fetchProfile: () => Promise<void>;
+}
+
+/** Value returned by {@link useAuth}. All state properties are Kasper signals. */
+export interface AuthContextValue {
+  /** The OIDC configuration used to initialize the provider. */
+  readonly config: OidcConfig;
+  /** The authenticated user, or null if not authenticated. */
+  readonly user: Signal<AuthUser | null>;
+  /** Whether the user is currently authenticated. */
+  readonly isAuthenticated: Signal<boolean>;
+  /** Whether the auth state is still being determined. */
+  readonly isLoading: Signal<boolean>;
+  /** The most recent authentication error, or null. */
+  readonly error: Signal<Error | null>;
+  /** Current token set (access, id, refresh, expiresAt). */
+  readonly tokens: Signal<AuthTokens>;
+  /** Actions for login, logout, refresh, and profile fetching. */
+  readonly actions: AuthActions;
+}

--- a/packages/kasper/tsconfig.json
+++ b/packages/kasper/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src"]
+}

--- a/packages/kasper/tsconfig.typedoc.json
+++ b/packages/kasper/tsconfig.typedoc.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "lib": ["ES2022", "DOM"],
+    "paths": {
+      "oidc-js-core": ["../core/src/index.ts"],
+      "oidc-js": ["../client/src/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["src/tests"]
+}

--- a/packages/kasper/vite.config.ts
+++ b/packages/kasper/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vite";
+import dts from "vite-plugin-dts";
+
+export default defineConfig({
+  plugins: [dts({ rollupTypes: true })],
+  build: {
+    lib: {
+      entry: "src/index.ts",
+      formats: ["es", "cjs"],
+      fileName: (format) => `index.${format === "es" ? "js" : "cjs"}`,
+    },
+    sourcemap: true,
+    rollupOptions: {
+      external: ["kasper-js", "oidc-js", "oidc-js-core"],
+    },
+  },
+  test: {
+    environment: "jsdom",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,34 @@ importers:
         specifier: ^4.0.0
         version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
 
+  packages/kasper:
+    dependencies:
+      oidc-js:
+        specifier: workspace:*
+        version: link:../client
+      oidc-js-core:
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      jsdom:
+        specifier: ^26.0.0
+        version: 26.1.0
+      kasper-js:
+        specifier: ^0.3.25
+        version: 0.3.25
+      typescript:
+        specifier: ^5.5.0
+        version: 5.6.3
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)
+      vite-plugin-dts:
+        specifier: ^4.0.0
+        version: 4.5.4(@types/node@25.6.0)(rollup@4.60.2)(typescript@5.6.3)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
+      vitest:
+        specifier: ^4.0.0
+        version: 4.1.5(@types/node@25.6.0)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3))
+
   packages/lit:
     dependencies:
       oidc-js:
@@ -359,6 +387,25 @@ importers:
       typescript:
         specifier: ~5.6.0
         version: 5.6.3
+
+  tests/e2e/kasper-app:
+    dependencies:
+      kasper-js:
+        specifier: ^0.3.25
+        version: 0.3.25
+      oidc-js-kasper:
+        specifier: workspace:*
+        version: link:../../../packages/kasper
+    devDependencies:
+      typescript:
+        specifier: ^5.5.0
+        version: 5.6.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(sass@1.85.0)(yaml@2.8.3)
+      vite-plugin-kasper:
+        specifier: ^0.1.4
+        version: 0.1.4(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(sass@1.85.0)(yaml@2.8.3))
 
   tests/e2e/lit-app:
     dependencies:
@@ -4483,6 +4530,9 @@ packages:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
 
+  kasper-js@0.3.25:
+    resolution: {integrity: sha512-u95QC7INdQsGLtuVdsE9AwBlcfZT2POfOo/WPaYi4xR58b3ifwpuBw25YcIatlmOU3GmNh6PB61T7rMqw95wxg==}
+
   katex@0.16.45:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
     hasBin: true
@@ -6072,6 +6122,11 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vite-plugin-kasper@0.1.4:
+    resolution: {integrity: sha512-SNnVMvtPbLBQtfltSXTSratdayrwdgVF3vT+ZPJwciY8MKp5GEr+OVDYtjoYpidtygEsWHsQEoCw/Jc8spiBzg==}
+    peerDependencies:
+      vite: '>=5.0.0'
 
   vite-plugin-solid@2.11.12:
     resolution: {integrity: sha512-FgjPcx2OwX9h6f28jli7A4bG7PP3te8uyakE5iqsmpq3Jqi1TWLgSroC9N6cMfGRU2zXsl4Q6ISvTr2VL0QHpA==}
@@ -10655,6 +10710,8 @@ snapshots:
 
   jsonparse@1.3.1: {}
 
+  kasper-js@0.3.25: {}
+
   katex@0.16.45:
     dependencies:
       commander: 8.3.0
@@ -12823,6 +12880,10 @@ snapshots:
       - '@types/node'
       - rollup
       - supports-color
+
+  vite-plugin-kasper@0.1.4(vite@6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(sass@1.85.0)(yaml@2.8.3)):
+    dependencies:
+      vite: 6.4.2(@types/node@25.6.0)(lightningcss@1.32.0)(sass@1.85.0)(yaml@2.8.3)
 
   vite-plugin-solid@2.11.12(solid-js@1.9.12)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(sass@1.85.0)(yaml@2.8.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,4 +8,5 @@ packages:
   - "tests/e2e/angular-app"
   - "tests/e2e/solid-app"
   - "tests/e2e/preact-app"
+  - "tests/e2e/kasper-app"
   - "docs-web"

--- a/tests/e2e/kasper-app/index.html
+++ b/tests/e2e/kasper-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>E2E Kasper App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/tests/e2e/kasper-app/package.json
+++ b/tests/e2e/kasper-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "e2e-kasper-app",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "oidc-js-kasper": "workspace:*",
+    "kasper-js": "^0.3.25"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.0",
+    "vite": "^6.0.0",
+    "vite-plugin-kasper": "^0.1.4"
+  }
+}

--- a/tests/e2e/kasper-app/src/components/App.kasper
+++ b/tests/e2e/kasper-app/src/components/App.kasper
@@ -1,0 +1,34 @@
+<template>
+  <auth-provider @:config="config" @:fetchProfile="fetchProfile" @:onLogin="handleLogin">
+    <router>
+      <route @path="/" @component="HomePage" />
+      <route @path="/callback" @component="CallbackPage" />
+      <route @path="/protected-a" @component="ProtectedAPage" />
+      <route @path="/protected-b" @component="ProtectedBPage" />
+    </router>
+  </auth-provider>
+</template>
+
+<script>
+import { Component, navigate } from "kasper-js";
+import { HomePage } from "./Home.kasper";
+import { CallbackPage } from "./Callback.kasper";
+import { ProtectedAPage } from "./ProtectedA.kasper";
+import { ProtectedBPage } from "./ProtectedB.kasper";
+
+export class AppRoot extends Component {
+  fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+
+  config = {
+    issuer: "http://localhost:9999/oauth2",
+    clientId: "e2e-test-app",
+    redirectUri: "http://localhost:5173/callback",
+    scopes: ["openid", "profile", "email", "offline_access"],
+    postLogoutRedirectUri: "http://localhost:5173",
+  };
+
+  handleLogin = (returnTo) => {
+    navigate(returnTo);
+  };
+}
+</script>

--- a/tests/e2e/kasper-app/src/components/Callback.kasper
+++ b/tests/e2e/kasper-app/src/components/Callback.kasper
@@ -1,0 +1,9 @@
+<template>
+  <div data-testid="auth-loading">Loading...</div>
+</template>
+
+<script>
+import { Component } from "kasper-js";
+
+export class CallbackPage extends Component {}
+</script>

--- a/tests/e2e/kasper-app/src/components/Home.kasper
+++ b/tests/e2e/kasper-app/src/components/Home.kasper
@@ -1,0 +1,52 @@
+<template>
+  <div @if="auth.isLoading.value" data-testid="auth-loading">Loading...</div>
+  <div @elseif="auth.error.value" data-testid="auth-error">Error: {{auth.error.value.message}}</div>
+  <div @elseif="!auth.isAuthenticated.value" data-testid="unauthenticated">
+    <h1>Not logged in</h1>
+    <button data-testid="login-button" @on:click="auth.actions.login()">Login</button>
+  </div>
+  <div @else data-testid="authenticated">
+    <h1>Logged in</h1>
+    <div data-testid="user-sub">{{auth.user.value?.claims.sub}}</div>
+    <div data-testid="user-iss">{{auth.user.value?.claims.iss}}</div>
+    <div data-testid="user-aud">{{formatAud()}}</div>
+    <div data-testid="user-exp">{{auth.user.value?.claims.exp}}</div>
+    <div data-testid="user-iat">{{auth.user.value?.claims.iat}}</div>
+    <div data-testid="user-email">{{auth.user.value?.profile?.email ?? "no profile"}}</div>
+    <div data-testid="user-profile-null">{{auth.user.value?.profile === null ? "true" : "false"}}</div>
+    <div data-testid="access-token">{{auth.tokens.value.access ? "present" : "missing"}}</div>
+    <div data-testid="refresh-token">{{auth.tokens.value.refresh ? "present" : "missing"}}</div>
+    <div data-testid="access-token-value" style="display: none">{{auth.tokens.value.access ?? ""}}</div>
+    <div data-testid="refresh-token-value" style="display: none">{{auth.tokens.value.refresh ?? ""}}</div>
+    <div data-testid="id-token">{{auth.tokens.value.id ? "present" : "missing"}}</div>
+    <div data-testid="expires-at">{{auth.tokens.value.expiresAt ?? "none"}}</div>
+    <button data-testid="logout-button" @on:click="auth.actions.logout()">Logout</button>
+    <button data-testid="refresh-button" @on:click="handleRefresh()">Refresh</button>
+    <nav>
+      <a href="/protected-a" data-testid="link-protected-a" @on:click.prevent="goTo('/protected-a')">Protected A</a>
+      <a href="/protected-b" data-testid="link-protected-b" @on:click.prevent="goTo('/protected-b')">Protected B</a>
+    </nav>
+  </div>
+</template>
+
+<script>
+import { Component, navigate } from "kasper-js";
+import { useAuth } from "oidc-js-kasper";
+
+export class HomePage extends Component {
+  auth = useAuth();
+
+  formatAud() {
+    const aud = this.auth.user.value?.claims.aud;
+    return typeof aud === "string" ? aud : JSON.stringify(aud);
+  }
+
+  handleRefresh() {
+    this.auth.actions.refresh().catch(() => {});
+  }
+
+  goTo(path) {
+    navigate(path);
+  }
+}
+</script>

--- a/tests/e2e/kasper-app/src/components/ProtectedA.kasper
+++ b/tests/e2e/kasper-app/src/components/ProtectedA.kasper
@@ -1,0 +1,21 @@
+<template>
+  <require-auth>
+    <div @slot="fallback" data-testid="auth-loading">Refreshing...</div>
+    <div data-testid="protected-a">Protected content a</div>
+    <nav>
+      <a href="/" data-testid="link-home" @on:click.prevent="goTo('/')">Home</a>
+      <a href="/protected-a" data-testid="link-protected-a" @on:click.prevent="goTo('/protected-a')">Protected A</a>
+      <a href="/protected-b" data-testid="link-protected-b" @on:click.prevent="goTo('/protected-b')">Protected B</a>
+    </nav>
+  </require-auth>
+</template>
+
+<script>
+import { Component, navigate } from "kasper-js";
+
+export class ProtectedAPage extends Component {
+  goTo(path) {
+    navigate(path);
+  }
+}
+</script>

--- a/tests/e2e/kasper-app/src/components/ProtectedB.kasper
+++ b/tests/e2e/kasper-app/src/components/ProtectedB.kasper
@@ -1,0 +1,21 @@
+<template>
+  <require-auth>
+    <div @slot="fallback" data-testid="auth-loading">Refreshing...</div>
+    <div data-testid="protected-b">Protected content b</div>
+    <nav>
+      <a href="/" data-testid="link-home" @on:click.prevent="goTo('/')">Home</a>
+      <a href="/protected-a" data-testid="link-protected-a" @on:click.prevent="goTo('/protected-a')">Protected A</a>
+      <a href="/protected-b" data-testid="link-protected-b" @on:click.prevent="goTo('/protected-b')">Protected B</a>
+    </nav>
+  </require-auth>
+</template>
+
+<script>
+import { Component, navigate } from "kasper-js";
+
+export class ProtectedBPage extends Component {
+  goTo(path) {
+    navigate(path);
+  }
+}
+</script>

--- a/tests/e2e/kasper-app/src/kasper.d.ts
+++ b/tests/e2e/kasper-app/src/kasper.d.ts
@@ -1,6 +1,6 @@
 declare module "*.kasper" {
   import type { Component } from "kasper-js";
-  type AnyComponent = new (...args: any[]) => Component;
+  type AnyComponent = new (...args: unknown[]) => Component;
   const exports: Record<string, AnyComponent>;
   export = exports;
 }

--- a/tests/e2e/kasper-app/src/kasper.d.ts
+++ b/tests/e2e/kasper-app/src/kasper.d.ts
@@ -1,0 +1,6 @@
+declare module "*.kasper" {
+  import type { Component } from "kasper-js";
+  type AnyComponent = new (...args: any[]) => Component;
+  const exports: Record<string, AnyComponent>;
+  export = exports;
+}

--- a/tests/e2e/kasper-app/src/main.ts
+++ b/tests/e2e/kasper-app/src/main.ts
@@ -1,0 +1,13 @@
+import { App } from "kasper-js";
+import { AppRoot } from "./components/App.kasper";
+import { AuthProvider, RequireAuth } from "oidc-js-kasper";
+
+App({
+  root: document.getElementById("root")!,
+  entry: "app-root",
+  registry: {
+    "app-root": { component: AppRoot },
+    "auth-provider": { component: AuthProvider },
+    "require-auth": { component: RequireAuth },
+  },
+});

--- a/tests/e2e/kasper-app/tsconfig.json
+++ b/tests/e2e/kasper-app/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src"]
+}

--- a/tests/e2e/kasper-app/vite.config.ts
+++ b/tests/e2e/kasper-app/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite";
+import kasper from "vite-plugin-kasper";
+
+export default defineConfig({
+  plugins: [kasper()],
+  server: {
+    port: 5173,
+    strictPort: true,
+  },
+});

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -11,6 +11,7 @@
     "test:angular": "playwright test --config=playwright.angular.config.ts",
     "test:solid": "playwright test --config playwright.solid.config.ts",
     "test:preact": "playwright test --config playwright.preact.config.ts",
+    "test:kasper": "playwright test --config playwright.kasper.config.ts",
     "test:ui": "playwright test --ui",
     "test:stress": "bash run-all.sh --repeat-each=10"
   },

--- a/tests/e2e/playwright.kasper.config.ts
+++ b/tests/e2e/playwright.kasper.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./specs",
+  timeout: 30_000,
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: "http://localhost:5173",
+    headless: true,
+  },
+  globalSetup: "./global-setup.ts",
+  globalTeardown: "./global-teardown.ts",
+  webServer: {
+    command: "pnpm --dir kasper-app dev",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 15_000,
+  },
+});

--- a/tests/e2e/run-all.sh
+++ b/tests/e2e/run-all.sh
@@ -9,6 +9,7 @@ configs=(
   "playwright.solid.config.ts:solid"
   "playwright.svelte.config.ts:svelte"
   "playwright.vue.config.ts:vue"
+  "playwright.kasper.config.ts:kasper"
 )
 
 for entry in "${configs[@]}"; do


### PR DESCRIPTION
## Summary

- Add `oidc-js-kasper` adapter package for the [Kasper.js](https://kasperjs.top) framework
- Pure TypeScript library — `AuthProvider`, `RequireAuth`, and `useAuth()` using Kasper's signal-based reactivity
- E2E test app with Kasper router and all shared Playwright specs (20/20 passing)
- Wired into CI via `run-all.sh`, workspace, and Playwright config

### Kasper-specific design notes

- Library is plain TypeScript (`static template` on components), no `vite-plugin-kasper` needed at build time
- Signal updates from OidcClient wrapped in `batch()` to prevent effects from firing mid-update
- Logout action unsubscribes before navigating to prevent RequireAuth from racing with the redirect

## Test plan

- [x] `pnpm --filter oidc-js-kasper build` succeeds
- [x] `pnpm --filter oidc-js-kasper lint` passes
- [x] `pnpm --filter e2e-tests test:kasper` — 20/20 E2E specs pass
- [ ] CI runs all framework E2E suites including kasper

🤖 Generated with [Claude Code](https://claude.com/claude-code)