### PR TITLE
fix: isolate E2E suites with per-framework ports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
 
       - name: Dump Autentico logs
         if: failure()
-        run: cat tests/e2e/autentico.log || true
+        run: cat tests/e2e/.autentico/logs/*.log || true

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ coverage/
 
 # E2E test artifacts
 tests/e2e/.env
-tests/e2e/autentico.db
-tests/e2e/autentico.log
+tests/e2e/autentico*.db
+tests/e2e/autentico*.log

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ coverage/
 
 # E2E test artifacts
 tests/e2e/.env
-tests/e2e/autentico*.db
-tests/e2e/autentico*.log
+tests/e2e/.autentico/db/
+tests/e2e/.autentico/logs/

--- a/README.md
+++ b/README.md
@@ -270,8 +270,17 @@ pnpm build
 # Build core only
 pnpm --filter oidc-js-core build
 
-# Run tests
-pnpm --filter oidc-js-core test
+# Run unit tests
+pnpm test
+
+# Run E2E tests (sequential, all 8 frameworks)
+pnpm test:e2e
+
+# Run E2E tests in parallel (4 at a time)
+MAX_PARALLEL=4 pnpm test:e2e
+
+# Run E2E stress test (10x repetition per framework)
+pnpm test:stress
 
 # Type check
 pnpm --filter oidc-js-core lint

--- a/tests/e2e/angular-app/angular.json
+++ b/tests/e2e/angular-app/angular.json
@@ -20,8 +20,7 @@
         "serve": {
           "builder": "@angular/build:dev-server",
           "options": {
-            "buildTarget": "e2e-angular-app:build",
-            "port": 5173
+            "buildTarget": "e2e-angular-app:build"
           }
         }
       }

--- a/tests/e2e/angular-app/package.json
+++ b/tests/e2e/angular-app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "ng serve --port 5173",
+    "dev": "ng serve",
     "build": "ng build"
   },
   "dependencies": {

--- a/tests/e2e/angular-app/src/main.ts
+++ b/tests/e2e/angular-app/src/main.ts
@@ -7,13 +7,17 @@ import { AppComponent } from "./app/app.component";
 import { routes } from "./app/app.routes";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const viteEnv = (import.meta as any).env ?? {};
+const idpPort = viteEnv.VITE_IDP_PORT ?? "9999";
+const appPort = viteEnv.VITE_APP_PORT ?? "5173";
 
 const config = {
-  issuer: "http://localhost:9999/oauth2",
+  issuer: `http://localhost:${idpPort}/oauth2`,
   clientId: "e2e-test-app",
-  redirectUri: "http://localhost:5173/callback",
+  redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
-  postLogoutRedirectUri: "http://localhost:5173",
+  postLogoutRedirectUri: `http://localhost:${appPort}`,
 };
 
 bootstrapApplication(AppComponent, {

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -5,7 +5,6 @@ import { join } from "path";
 const AUTENTICO_DIR = join(import.meta.dirname, ".autentico");
 const AUTENTICO_BIN = join(AUTENTICO_DIR, "autentico");
 const AUTENTICO_RELEASE = "https://github.com/eugenioenko/autentico/releases/download/v2.0.0-beta.1/autentico-linux-amd64";
-const AUTENTICO_URL = "http://localhost:9999";
 
 export default async function globalSetup() {
   mkdirSync(AUTENTICO_DIR, { recursive: true });
@@ -14,11 +13,5 @@ export default async function globalSetup() {
     console.log("Downloading autentico...");
     execSync(`curl -fsSL -o ${AUTENTICO_BIN} ${AUTENTICO_RELEASE}`, { stdio: "inherit" });
     chmodSync(AUTENTICO_BIN, 0o755);
-  }
-
-  const envFile = join(AUTENTICO_DIR, ".env");
-  if (!existsSync(envFile)) {
-    console.log("Initializing autentico...");
-    execSync(`${AUTENTICO_BIN} init --url ${AUTENTICO_URL}`, { cwd: AUTENTICO_DIR, stdio: "inherit" });
   }
 }

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,13 +1,3 @@
-import { existsSync, copyFileSync } from "fs";
-import { join } from "path";
-
-const IDP_PORT = process.env.E2E_IDP_PORT ?? "9999";
-const AUTENTICO_DIR = join(import.meta.dirname, ".autentico");
-
 export default async function globalTeardown() {
-  const logSrc = join(AUTENTICO_DIR, `autentico-${IDP_PORT}.log`);
-  const logDst = join(import.meta.dirname, `autentico-${IDP_PORT}.log`);
-  if (existsSync(logSrc)) {
-    copyFileSync(logSrc, logDst);
-  }
+  // Logs are written to .autentico/logs/ — nothing to copy
 }

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,11 +1,12 @@
 import { existsSync, copyFileSync } from "fs";
 import { join } from "path";
 
+const IDP_PORT = process.env.E2E_IDP_PORT ?? "9999";
 const AUTENTICO_DIR = join(import.meta.dirname, ".autentico");
 
 export default async function globalTeardown() {
-  const logSrc = join(AUTENTICO_DIR, "autentico.log");
-  const logDst = join(import.meta.dirname, "autentico.log");
+  const logSrc = join(AUTENTICO_DIR, `autentico-${IDP_PORT}.log`);
+  const logDst = join(import.meta.dirname, `autentico-${IDP_PORT}.log`);
   if (existsSync(logSrc)) {
     copyFileSync(logSrc, logDst);
   }

--- a/tests/e2e/kasper-app/src/components/App.kasper
+++ b/tests/e2e/kasper-app/src/components/App.kasper
@@ -19,13 +19,17 @@ import { ProtectedBPage } from "./ProtectedB.kasper";
 export class AppRoot extends Component {
   fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
 
-  config = {
-    issuer: "http://localhost:9999/oauth2",
-    clientId: "e2e-test-app",
-    redirectUri: "http://localhost:5173/callback",
-    scopes: ["openid", "profile", "email", "offline_access"],
-    postLogoutRedirectUri: "http://localhost:5173",
-  };
+  config = (() => {
+    const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
+    const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
+    return {
+      issuer: `http://localhost:${idpPort}/oauth2`,
+      clientId: "e2e-test-app",
+      redirectUri: `http://localhost:${appPort}/callback`,
+      scopes: ["openid", "profile", "email", "offline_access"],
+      postLogoutRedirectUri: `http://localhost:${appPort}`,
+    };
+  })();
 
   handleLogin = (returnTo) => {
     navigate(returnTo);

--- a/tests/e2e/lit-app/src/app-root.ts
+++ b/tests/e2e/lit-app/src/app-root.ts
@@ -7,13 +7,15 @@ import "./pages/protected-a-page.js";
 import "./pages/protected-b-page.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
+const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
 const config = {
-  issuer: "http://localhost:9999/oauth2",
+  issuer: `http://localhost:${idpPort}/oauth2`,
   clientId: "e2e-test-app",
-  redirectUri: "http://localhost:5173/callback",
+  redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
-  postLogoutRedirectUri: "http://localhost:5173",
+  postLogoutRedirectUri: `http://localhost:${appPort}`,
 };
 
 @customElement("app-root")

--- a/tests/e2e/playwright.angular.config.ts
+++ b/tests/e2e/playwright.angular.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
+
 export default defineConfig({
   testDir: "./specs",
   timeout: 30_000,
@@ -7,15 +9,15 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${APP_PORT}`,
     headless: true,
   },
   globalSetup: "./global-setup.ts",
   globalTeardown: "./global-teardown.ts",
   webServer: {
-    command: "pnpm --dir angular-app dev",
-    url: "http://localhost:5173",
+    command: `pnpm --dir angular-app dev --port ${APP_PORT}`,
+    url: `http://localhost:${APP_PORT}`,
     reuseExistingServer: !process.env.CI,
-    timeout: 30_000,
+    timeout: 30000,
   },
 });

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
+
 export default defineConfig({
   testDir: "./specs",
   timeout: 30_000,
@@ -7,14 +9,14 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${APP_PORT}`,
     headless: true,
   },
   globalSetup: "./global-setup.ts",
   globalTeardown: "./global-teardown.ts",
   webServer: {
-    command: "pnpm --dir react-app dev",
-    url: "http://localhost:5173",
+    command: `pnpm --dir react-app dev --port ${APP_PORT}`,
+    url: `http://localhost:${APP_PORT}`,
     reuseExistingServer: !process.env.CI,
     timeout: 15_000,
   },

--- a/tests/e2e/playwright.kasper.config.ts
+++ b/tests/e2e/playwright.kasper.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
+
 export default defineConfig({
   testDir: "./specs",
   timeout: 30_000,
@@ -7,15 +9,15 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${APP_PORT}`,
     headless: true,
   },
   globalSetup: "./global-setup.ts",
   globalTeardown: "./global-teardown.ts",
   webServer: {
-    command: "pnpm --dir kasper-app dev",
-    url: "http://localhost:5173",
+    command: `pnpm --dir kasper-app dev --port ${APP_PORT}`,
+    url: `http://localhost:${APP_PORT}`,
     reuseExistingServer: !process.env.CI,
-    timeout: 15_000,
+    timeout: 15000,
   },
 });

--- a/tests/e2e/playwright.lit.config.ts
+++ b/tests/e2e/playwright.lit.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
+
 export default defineConfig({
   testDir: "./specs",
   timeout: 30_000,
@@ -7,15 +9,15 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${APP_PORT}`,
     headless: true,
   },
   globalSetup: "./global-setup.ts",
   globalTeardown: "./global-teardown.ts",
   webServer: {
-    command: "pnpm --dir lit-app dev",
-    url: "http://localhost:5173",
+    command: `pnpm --dir lit-app dev --port ${APP_PORT}`,
+    url: `http://localhost:${APP_PORT}`,
     reuseExistingServer: !process.env.CI,
-    timeout: 15_000,
+    timeout: 15000,
   },
 });

--- a/tests/e2e/playwright.preact.config.ts
+++ b/tests/e2e/playwright.preact.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
+
 export default defineConfig({
   testDir: "./specs",
   timeout: 30_000,
@@ -7,15 +9,15 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${APP_PORT}`,
     headless: true,
   },
   globalSetup: "./global-setup.ts",
   globalTeardown: "./global-teardown.ts",
   webServer: {
-    command: "pnpm --dir preact-app dev",
-    url: "http://localhost:5173",
+    command: `pnpm --dir preact-app dev --port ${APP_PORT}`,
+    url: `http://localhost:${APP_PORT}`,
     reuseExistingServer: !process.env.CI,
-    timeout: 15_000,
+    timeout: 15000,
   },
 });

--- a/tests/e2e/playwright.solid.config.ts
+++ b/tests/e2e/playwright.solid.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
+
 export default defineConfig({
   testDir: "./specs",
   timeout: 30_000,
@@ -7,15 +9,15 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${APP_PORT}`,
     headless: true,
   },
   globalSetup: "./global-setup.ts",
   globalTeardown: "./global-teardown.ts",
   webServer: {
-    command: "pnpm --dir solid-app dev",
-    url: "http://localhost:5173",
+    command: `pnpm --dir solid-app dev --port ${APP_PORT}`,
+    url: `http://localhost:${APP_PORT}`,
     reuseExistingServer: !process.env.CI,
-    timeout: 15_000,
+    timeout: 15000,
   },
 });

--- a/tests/e2e/playwright.svelte.config.ts
+++ b/tests/e2e/playwright.svelte.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
+
 export default defineConfig({
   testDir: "./specs",
   timeout: 30_000,
@@ -7,15 +9,15 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${APP_PORT}`,
     headless: true,
   },
   globalSetup: "./global-setup.ts",
   globalTeardown: "./global-teardown.ts",
   webServer: {
-    command: "pnpm --dir svelte-app dev",
-    url: "http://localhost:5173",
+    command: `pnpm --dir svelte-app dev --port ${APP_PORT}`,
+    url: `http://localhost:${APP_PORT}`,
     reuseExistingServer: !process.env.CI,
-    timeout: 15_000,
+    timeout: 15000,
   },
 });

--- a/tests/e2e/playwright.vue.config.ts
+++ b/tests/e2e/playwright.vue.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
+
 export default defineConfig({
   testDir: "./specs",
   timeout: 30_000,
@@ -7,15 +9,15 @@ export default defineConfig({
   workers: 1,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${APP_PORT}`,
     headless: true,
   },
   globalSetup: "./global-setup.ts",
   globalTeardown: "./global-teardown.ts",
   webServer: {
-    command: "pnpm --dir vue-app dev",
-    url: "http://localhost:5173",
+    command: `pnpm --dir vue-app dev --port ${APP_PORT}`,
+    url: `http://localhost:${APP_PORT}`,
     reuseExistingServer: !process.env.CI,
-    timeout: 15_000,
+    timeout: 15000,
   },
 });

--- a/tests/e2e/preact-app/src/index.tsx
+++ b/tests/e2e/preact-app/src/index.tsx
@@ -5,13 +5,15 @@ import { useCallback } from "preact/hooks";
 import { App } from "./App.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
+const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
 const config = {
-  issuer: "http://localhost:9999/oauth2",
+  issuer: `http://localhost:${idpPort}/oauth2`,
   clientId: "e2e-test-app",
-  redirectUri: "http://localhost:5173/callback",
+  redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
-  postLogoutRedirectUri: "http://localhost:5173",
+  postLogoutRedirectUri: `http://localhost:${appPort}`,
 };
 
 function Root() {

--- a/tests/e2e/react-app/src/main.tsx
+++ b/tests/e2e/react-app/src/main.tsx
@@ -5,13 +5,15 @@ import { useCallback } from "react";
 import { App } from "./App.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
+const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
 const config = {
-  issuer: "http://localhost:9999/oauth2",
+  issuer: `http://localhost:${idpPort}/oauth2`,
   clientId: "e2e-test-app",
-  redirectUri: "http://localhost:5173/callback",
+  redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
-  postLogoutRedirectUri: "http://localhost:5173",
+  postLogoutRedirectUri: `http://localhost:${appPort}`,
 };
 
 function Root() {

--- a/tests/e2e/run-all.sh
+++ b/tests/e2e/run-all.sh
@@ -1,28 +1,82 @@
 #!/usr/bin/env bash
 set -e
 
+# Each entry: config:framework:idp_port:app_port
 configs=(
-  "playwright.config.ts:react"
-  "playwright.angular.config.ts:angular"
-  "playwright.lit.config.ts:lit"
-  "playwright.preact.config.ts:preact"
-  "playwright.solid.config.ts:solid"
-  "playwright.svelte.config.ts:svelte"
-  "playwright.vue.config.ts:vue"
-  "playwright.kasper.config.ts:kasper"
+  "playwright.config.ts:React:10001:20001"
+  "playwright.angular.config.ts:Angular:10002:20002"
+  "playwright.lit.config.ts:Lit:10003:20003"
+  "playwright.preact.config.ts:Preact:10004:20004"
+  "playwright.solid.config.ts:Solid:10005:20005"
+  "playwright.svelte.config.ts:Svelte:10006:20006"
+  "playwright.vue.config.ts:Vue:10007:20007"
+  "playwright.kasper.config.ts:Kasper:10008:20008"
 )
 
+MAX_PARALLEL=${MAX_PARALLEL:-1}
+pids=()
+names=()
+results=()
+failed=0
+
 for entry in "${configs[@]}"; do
-  config="${entry%%:*}"
-  name="${entry##*:}"
-  echo ""
-  echo "========================================="
-  echo " Running E2E tests: $name"
-  echo " Config: $config"
-  echo "========================================="
-  echo ""
-  pnpm exec playwright test --config "$config" "$@"
+  IFS=: read -r config name idp_port app_port <<< "$entry"
+
+  # Wait if we've hit the max parallel limit
+  while [ "${#pids[@]}" -ge "$MAX_PARALLEL" ]; do
+    # Wait for any one pid to finish
+    for i in "${!pids[@]}"; do
+      if ! kill -0 "${pids[$i]}" 2>/dev/null; then
+        if wait "${pids[$i]}"; then
+          results+=("✓ ${names[$i]}")
+        else
+          results+=("✗ ${names[$i]}")
+          failed=1
+        fi
+        unset 'pids[i]' 'names[i]'
+        # Re-index arrays
+        pids=("${pids[@]}")
+        names=("${names[@]}")
+        break
+      fi
+    done
+    sleep 0.2
+  done
+
+  echo "Starting E2E: $name (IDP:$idp_port APP:$app_port)"
+  E2E_IDP_PORT=$idp_port \
+  E2E_APP_PORT=$app_port \
+  E2E_FRAMEWORK=$name \
+  VITE_IDP_PORT=$idp_port \
+  VITE_APP_PORT=$app_port \
+  pnpm exec playwright test --config "$config" "$@" &
+  pids+=($!)
+  names+=("$name")
 done
+
+# Wait for remaining
+for i in "${!pids[@]}"; do
+  if wait "${pids[$i]}"; then
+    results+=("✓ ${names[$i]}")
+  else
+    results+=("✗ ${names[$i]}")
+    failed=1
+  fi
+done
+
+echo ""
+echo "========================================="
+echo " E2E Results"
+echo "========================================="
+for r in "${results[@]}"; do
+  echo "  $r"
+done
+echo "========================================="
+
+if [ $failed -ne 0 ]; then
+  echo "Some suites failed."
+  exit 1
+fi
 
 echo ""
 echo "All E2E test suites passed."

--- a/tests/e2e/solid-app/src/App.tsx
+++ b/tests/e2e/solid-app/src/App.tsx
@@ -3,13 +3,15 @@ import { AuthProvider } from "oidc-js-solid";
 import type { ParentComponent } from "solid-js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
+const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
 const config = {
-  issuer: "http://localhost:9999/oauth2",
+  issuer: `http://localhost:${idpPort}/oauth2`,
   clientId: "e2e-test-app",
-  redirectUri: "http://localhost:5173/callback",
+  redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
-  postLogoutRedirectUri: "http://localhost:5173",
+  postLogoutRedirectUri: `http://localhost:${appPort}`,
 };
 
 export const App: ParentComponent = (props) => {

--- a/tests/e2e/specs/autentico.fixture.ts
+++ b/tests/e2e/specs/autentico.fixture.ts
@@ -1,6 +1,6 @@
 import { test as base } from "@playwright/test";
 import { execSync, spawn } from "child_process";
-import { createWriteStream, existsSync, readFileSync, rmSync } from "fs";
+import { createWriteStream, existsSync, mkdirSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 
 const IDP_PORT = process.env.E2E_IDP_PORT ?? "9999";
@@ -8,8 +8,10 @@ const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
 const AUTENTICO_DIR = join(import.meta.dirname, "..", ".autentico");
 const AUTENTICO_BIN = join(AUTENTICO_DIR, "autentico");
 const ENV_FILE = join(AUTENTICO_DIR, ".env");
+const DB_DIR = join(AUTENTICO_DIR, "db");
+const LOG_DIR = join(AUTENTICO_DIR, "logs");
 const AUTENTICO_URL = `http://localhost:${IDP_PORT}`;
-const DB_FILE = `./autentico-${IDP_PORT}.db`;
+const DB_FILE = join(DB_DIR, `autentico-${IDP_PORT}.db`);
 const ADMIN_USER = "admin";
 const ADMIN_PASS = "TestAdmin123!";
 const ADMIN_EMAIL = "admin@test.com";
@@ -93,8 +95,9 @@ async function seedTestData(token: string) {
 }
 
 function cleanDb() {
+  mkdirSync(DB_DIR, { recursive: true });
   for (const suffix of ["", "-shm", "-wal"]) {
-    const p = join(AUTENTICO_DIR, `autentico-${IDP_PORT}.db${suffix}`);
+    const p = `${DB_FILE}${suffix}`;
     if (existsSync(p)) rmSync(p);
   }
 }
@@ -123,7 +126,8 @@ export const test = base.extend<{ autentico: void }>({
       { cwd: AUTENTICO_DIR, stdio: "pipe", env: envVars },
     );
 
-    const logFile = createWriteStream(join(AUTENTICO_DIR, `autentico-${IDP_PORT}.log`));
+    mkdirSync(LOG_DIR, { recursive: true });
+    const logFile = createWriteStream(join(LOG_DIR, `autentico-${IDP_PORT}.log`));
     const proc = spawn(AUTENTICO_BIN, ["start"], {
       cwd: AUTENTICO_DIR,
       stdio: ["ignore", "pipe", "pipe"],

--- a/tests/e2e/specs/autentico.fixture.ts
+++ b/tests/e2e/specs/autentico.fixture.ts
@@ -1,17 +1,34 @@
 import { test as base } from "@playwright/test";
 import { execSync, spawn } from "child_process";
-import { createWriteStream, existsSync, rmSync } from "fs";
+import { createWriteStream, existsSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 
+const IDP_PORT = process.env.E2E_IDP_PORT ?? "9999";
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
 const AUTENTICO_DIR = join(import.meta.dirname, "..", ".autentico");
 const AUTENTICO_BIN = join(AUTENTICO_DIR, "autentico");
-const AUTENTICO_URL = "http://localhost:9999";
+const ENV_FILE = join(AUTENTICO_DIR, ".env");
+const AUTENTICO_URL = `http://localhost:${IDP_PORT}`;
+const DB_FILE = `./autentico-${IDP_PORT}.db`;
 const ADMIN_USER = "admin";
 const ADMIN_PASS = "TestAdmin123!";
 const ADMIN_EMAIL = "admin@test.com";
 const TEST_USER = "testuser";
 const TEST_PASS = "TestUser123!";
 const TEST_EMAIL = "testuser@test.com";
+
+function readEnvFile(): Record<string, string> {
+  const env: Record<string, string> = {};
+  if (!existsSync(ENV_FILE)) return env;
+  for (const line of readFileSync(ENV_FILE, "utf-8").split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    env[trimmed.slice(0, eq)] = trimmed.slice(eq + 1);
+  }
+  return env;
+}
 
 async function waitForHealthy(url: string, timeoutMs = 15_000) {
   const start = Date.now();
@@ -49,8 +66,8 @@ async function seedTestData(token: string) {
     body: JSON.stringify({
       client_id: "e2e-test-app",
       client_name: "E2E Test App",
-      redirect_uris: ["http://localhost:5173/callback"],
-      post_logout_redirect_uris: ["http://localhost:5173"],
+      redirect_uris: [`http://localhost:${APP_PORT}/callback`],
+      post_logout_redirect_uris: [`http://localhost:${APP_PORT}`],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       scopes: "openid profile email offline_access",
@@ -76,8 +93,8 @@ async function seedTestData(token: string) {
 }
 
 function cleanDb() {
-  for (const f of ["autentico.db", "autentico.db-shm", "autentico.db-wal"]) {
-    const p = join(AUTENTICO_DIR, f);
+  for (const suffix of ["", "-shm", "-wal"]) {
+    const p = join(AUTENTICO_DIR, `autentico-${IDP_PORT}.db${suffix}`);
     if (existsSync(p)) rmSync(p);
   }
 }
@@ -87,22 +104,30 @@ export const test = base.extend<{ autentico: void }>({
   autentico: [async ({}, use) => {
     cleanDb();
 
+    const envVars = {
+      ...process.env,
+      ...readEnvFile(),
+      AUTENTICO_DB_FILE_PATH: DB_FILE,
+      AUTENTICO_APP_URL: AUTENTICO_URL,
+      AUTENTICO_LISTEN_PORT: IDP_PORT,
+      AUTENTICO_RATE_LIMIT_RPS: "0",
+      AUTENTICO_RATE_LIMIT_RPM: "0",
+      AUTENTICO_ANTI_TIMING_MIN_MS: "0",
+      AUTENTICO_ANTI_TIMING_MAX_MS: "0",
+      AUTENTICO_CSRF_SECURE_COOKIE: "false",
+      AUTENTICO_IDP_SESSION_SECURE: "false",
+    };
+
     execSync(
       `${AUTENTICO_BIN} onboard --username ${ADMIN_USER} --password "${ADMIN_PASS}" --email ${ADMIN_EMAIL} --enable-admin-password-grant`,
-      { cwd: AUTENTICO_DIR, stdio: "pipe" },
+      { cwd: AUTENTICO_DIR, stdio: "pipe", env: envVars },
     );
 
-    const logFile = createWriteStream(join(AUTENTICO_DIR, "autentico.log"));
+    const logFile = createWriteStream(join(AUTENTICO_DIR, `autentico-${IDP_PORT}.log`));
     const proc = spawn(AUTENTICO_BIN, ["start"], {
       cwd: AUTENTICO_DIR,
       stdio: ["ignore", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        AUTENTICO_RATE_LIMIT_RPS: "0",
-        AUTENTICO_RATE_LIMIT_RPM: "0",
-        AUTENTICO_ANTI_TIMING_MIN_MS: "0",
-        AUTENTICO_ANTI_TIMING_MAX_MS: "0",
-      },
+      env: envVars,
     });
     proc.stdout?.pipe(logFile);
     proc.stderr?.pipe(logFile);

--- a/tests/e2e/specs/autentico.fixture.ts
+++ b/tests/e2e/specs/autentico.fixture.ts
@@ -1,13 +1,13 @@
 import { test as base } from "@playwright/test";
 import { execSync, spawn } from "child_process";
-import { createWriteStream, existsSync, mkdirSync, readFileSync, rmSync } from "fs";
+import { randomBytes, generateKeyPairSync } from "crypto";
+import { createWriteStream, existsSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 
 const IDP_PORT = process.env.E2E_IDP_PORT ?? "9999";
 const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
 const AUTENTICO_DIR = join(import.meta.dirname, "..", ".autentico");
 const AUTENTICO_BIN = join(AUTENTICO_DIR, "autentico");
-const ENV_FILE = join(AUTENTICO_DIR, ".env");
 const DB_DIR = join(AUTENTICO_DIR, "db");
 const LOG_DIR = join(AUTENTICO_DIR, "logs");
 const AUTENTICO_URL = `http://localhost:${IDP_PORT}`;
@@ -19,18 +19,12 @@ const TEST_USER = "testuser";
 const TEST_PASS = "TestUser123!";
 const TEST_EMAIL = "testuser@test.com";
 
-function readEnvFile(): Record<string, string> {
-  const env: Record<string, string> = {};
-  if (!existsSync(ENV_FILE)) return env;
-  for (const line of readFileSync(ENV_FILE, "utf-8").split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) continue;
-    const eq = trimmed.indexOf("=");
-    if (eq === -1) continue;
-    env[trimmed.slice(0, eq)] = trimmed.slice(eq + 1);
-  }
-  return env;
-}
+const ACCESS_TOKEN_SECRET = randomBytes(32).toString("hex");
+const REFRESH_TOKEN_SECRET = randomBytes(32).toString("hex");
+const CSRF_SECRET_KEY = randomBytes(32).toString("hex");
+const PRIVATE_KEY = generateKeyPairSync("rsa", { modulusLength: 2048 })
+  .privateKey.export({ type: "pkcs1", format: "pem" });
+const PRIVATE_KEY_B64 = Buffer.from(PRIVATE_KEY as string).toString("base64");
 
 async function waitForHealthy(url: string, timeoutMs = 15_000) {
   const start = Date.now();
@@ -104,17 +98,22 @@ function cleanDb() {
 
 export const test = base.extend<{ autentico: void }>({
   // eslint-disable-next-line no-empty-pattern
-  autentico: [async ({}, use) => {
+  autentico: [async ({ }, use) => {
     cleanDb();
 
     const envVars = {
       ...process.env,
-      ...readEnvFile(),
+      AUTENTICO_ACCESS_TOKEN_SECRET: ACCESS_TOKEN_SECRET,
+      AUTENTICO_REFRESH_TOKEN_SECRET: REFRESH_TOKEN_SECRET,
+      AUTENTICO_CSRF_SECRET_KEY: CSRF_SECRET_KEY,
+      AUTENTICO_PRIVATE_KEY: PRIVATE_KEY_B64,
       AUTENTICO_DB_FILE_PATH: DB_FILE,
       AUTENTICO_APP_URL: AUTENTICO_URL,
       AUTENTICO_LISTEN_PORT: IDP_PORT,
       AUTENTICO_RATE_LIMIT_RPS: "0",
       AUTENTICO_RATE_LIMIT_RPM: "0",
+      AUTENTICO_RATE_LIMIT_BURST: "0",
+      AUTENTICO_RATE_LIMIT_RPM_BURST: "0",
       AUTENTICO_ANTI_TIMING_MIN_MS: "0",
       AUTENTICO_ANTI_TIMING_MAX_MS: "0",
       AUTENTICO_CSRF_SECURE_COOKIE: "false",

--- a/tests/e2e/specs/login.spec.ts
+++ b/tests/e2e/specs/login.spec.ts
@@ -1,10 +1,17 @@
 import { test, expect } from "./autentico.fixture.js";
 import type { Page } from "@playwright/test";
 
-const AUTENTICO_URL = "http://localhost:9999";
+const IDP_PORT = process.env.E2E_IDP_PORT ?? "9999";
+const APP_PORT = process.env.E2E_APP_PORT ?? "5173";
+const FRAMEWORK = process.env.E2E_FRAMEWORK ?? "unknown";
+
+const AUTENTICO_URL = `http://localhost:${IDP_PORT}`;
 const TEST_USER = "testuser";
 const TEST_PASS = "TestUser123!";
 const TIMEOUT = 10_000;
+
+const idpPattern = new RegExp(`localhost:${IDP_PORT}`);
+const appPattern = new RegExp(`localhost:${APP_PORT}`);
 
 type TrafficEntry = { method: string; path: string };
 
@@ -46,11 +53,11 @@ function trackTraffic(page: Page) {
 async function login(page: Page) {
   await page.goto("/");
   await page.getByTestId("login-button").click();
-  await page.waitForURL(/localhost:9999/);
+  await page.waitForURL(idpPattern);
   await page.fill('input[name="username"]', TEST_USER);
   await page.fill('input[name="password"]', TEST_PASS);
   await page.click('button[type="submit"]');
-  await page.waitForURL(/localhost:5173/, { timeout: TIMEOUT });
+  await page.waitForURL(appPattern, { timeout: TIMEOUT });
   await expect(page.getByTestId("authenticated")).toBeVisible({ timeout: TIMEOUT });
 }
 
@@ -80,7 +87,7 @@ const LOGIN_NAVIGATIONS = [
   "/oauth2/authorize",
 ];
 
-test.describe("OIDC Login Flow", () => {
+test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
   test("shows login button when not authenticated", async ({ page }) => {
     const traffic = trackTraffic(page);
     await page.goto("/");
@@ -108,7 +115,7 @@ test.describe("OIDC Login Flow", () => {
     const traffic = trackTraffic(page);
     await login(page);
     await expect(page.getByTestId("user-sub")).not.toBeEmpty();
-    await expect(page.getByTestId("user-iss")).toHaveText("http://localhost:9999/oauth2");
+    await expect(page.getByTestId("user-iss")).toHaveText(`${AUTENTICO_URL}/oauth2`);
     await expect(page.getByTestId("user-aud")).not.toBeEmpty();
     await expect(page.getByTestId("user-exp")).not.toBeEmpty();
     await expect(page.getByTestId("user-iat")).not.toBeEmpty();
@@ -133,11 +140,11 @@ test.describe("OIDC Login Flow", () => {
     await page.evaluate(() => localStorage.setItem("e2e-fetchProfile", "false"));
     await page.reload();
     await page.getByTestId("login-button").click();
-    await page.waitForURL(/localhost:9999/);
+    await page.waitForURL(idpPattern);
     await page.fill('input[name="username"]', TEST_USER);
     await page.fill('input[name="password"]', TEST_PASS);
     await page.click('button[type="submit"]');
-    await page.waitForURL(/localhost:5173/);
+    await page.waitForURL(appPattern);
     await expect(page.getByTestId("authenticated")).toBeVisible();
     await expect(page.getByTestId("user-profile-null")).toHaveText("true");
     await expect(page.getByTestId("user-email")).toHaveText("no profile");
@@ -187,7 +194,7 @@ test.describe("OIDC Login Flow", () => {
   });
 });
 
-test.describe("Session Lifecycle", () => {
+test.describe(`[${FRAMEWORK}] Session Lifecycle`, () => {
   test("cleans callback URL params after login", async ({ page }) => {
     await login(page);
     const url = new URL(page.url());
@@ -212,11 +219,11 @@ test.describe("Session Lifecycle", () => {
     await expect(page.getByTestId("unauthenticated")).toBeVisible({ timeout: TIMEOUT });
 
     await page.getByTestId("login-button").click();
-    await page.waitForURL(/localhost:9999/);
+    await page.waitForURL(idpPattern);
     await page.fill('input[name="username"]', TEST_USER);
     await page.fill('input[name="password"]', TEST_PASS);
     await page.click('button[type="submit"]');
-    await page.waitForURL(/localhost:5173/, { timeout: TIMEOUT });
+    await page.waitForURL(appPattern, { timeout: TIMEOUT });
     await expect(page.getByTestId("authenticated")).toBeVisible({ timeout: TIMEOUT });
     await expect(page.getByTestId("access-token")).toHaveText("present");
   });
@@ -232,7 +239,7 @@ test.describe("Session Lifecycle", () => {
   });
 });
 
-test.describe("Security", () => {
+test.describe(`[${FRAMEWORK}] Security`, () => {
   test("tokens are not stored in localStorage or sessionStorage", async ({ page }) => {
     await login(page);
 
@@ -265,7 +272,7 @@ test.describe("Security", () => {
   });
 });
 
-test.describe("Error Handling", () => {
+test.describe(`[${FRAMEWORK}] Error Handling`, () => {
   test("shows error when IdP returns error in callback", async ({ page }) => {
     const traffic = trackTraffic(page);
     await page.goto("/?error=access_denied&error_description=User+denied+consent");
@@ -282,17 +289,15 @@ test.describe("Error Handling", () => {
     const traffic = trackTraffic(page);
     await page.goto("/");
 
-    // Plant a fake PKCE auth state with a known state value
-    await page.evaluate(() => {
+    await page.evaluate((appPort) => {
       sessionStorage.setItem("oidc-js:auth-state", JSON.stringify({
         codeVerifier: "fake-verifier",
         state: "correct-state",
         nonce: "fake-nonce",
-        redirectUri: "http://localhost:5173/callback",
+        redirectUri: `http://localhost:${appPort}/callback`,
       }));
-    });
+    }, APP_PORT);
 
-    // Navigate with a tampered state — should trigger state mismatch error
     await page.goto("/?code=fake-code&state=tampered-state");
     await expect(page.getByTestId("auth-error")).toBeVisible({ timeout: TIMEOUT });
     await expect(page.getByTestId("auth-error")).toContainText("State");
@@ -305,7 +310,7 @@ test.describe("Error Handling", () => {
   });
 });
 
-test.describe("Deep Linking", () => {
+test.describe(`[${FRAMEWORK}] Deep Linking`, () => {
   test("login from protected page returns to that page", async ({ page }) => {
     const traffic = trackTraffic(page);
     await page.goto("/protected-a", { waitUntil: "networkidle" });
@@ -315,7 +320,6 @@ test.describe("Deep Linking", () => {
     await page.fill('input[name="password"]', TEST_PASS);
     await page.click('button[type="submit"]');
 
-    // After login, should land back on /protected-a (not /)
     await expect(page.getByTestId("protected-a")).toBeVisible({ timeout: TIMEOUT });
     expect(page.url()).toContain("/protected-a");
 
@@ -324,7 +328,7 @@ test.describe("Deep Linking", () => {
   });
 });
 
-test.describe("RequireAuth", () => {
+test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
   test("shows protected content when authenticated", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -347,11 +351,9 @@ test.describe("RequireAuth", () => {
     await page.getByTestId("link-protected-a").click();
     await expect(page.getByTestId("protected-a")).toBeVisible();
 
-    // Navigate home and verify still authenticated
     await page.getByTestId("link-home").click();
     await expect(page.getByTestId("authenticated")).toBeVisible();
 
-    // No extra requests beyond the initial login flow
     expect(traffic.requests()).toEqual(LOGIN_REQUESTS);
     expect(traffic.navigations()).toEqual(LOGIN_NAVIGATIONS);
   });
@@ -364,10 +366,6 @@ test.describe("RequireAuth", () => {
     await page.getByTestId("link-protected-a").click();
     await expect(page.getByTestId("protected-a")).toBeVisible();
 
-    // Override Date.now and patch fetch so the clock is restored from inside
-    // the browser's promise chain — before React re-renders with new tokens.
-    // Restoring via Playwright's page.evaluate() would arrive as a macrotask,
-    // after React's synchronous re-render from the microtask chain.
     await page.evaluate((exp) => {
       const realDateNow = Date.now;
       const originalFetch = window.fetch;
@@ -383,7 +381,6 @@ test.describe("RequireAuth", () => {
       } as typeof fetch;
     }, expiresAt);
 
-    // Navigate to second protected page — RequireAuth should auto-refresh
     await page.getByTestId("link-protected-b").click();
     await expect(page.getByTestId("protected-b")).toBeVisible({ timeout: TIMEOUT });
 
@@ -407,8 +404,6 @@ test.describe("RequireAuth", () => {
 
     await revokeToken(refreshToken!, "refresh_token");
 
-    // Override Date.now and patch fetch to restore the clock from inside
-    // the browser's promise chain — before React re-renders.
     await page.evaluate((exp) => {
       const realDateNow = Date.now;
       const originalFetch = window.fetch;
@@ -424,11 +419,9 @@ test.describe("RequireAuth", () => {
       } as typeof fetch;
     }, expiresAt);
 
-    // Navigate to second protected page — refresh should fail, triggering login redirect
     await page.getByTestId("link-protected-b").click();
     await expect(page.locator('input[name="username"]')).toBeVisible({ timeout: TIMEOUT });
 
-    // Failed refresh POST + redirect to authorize
     expect(traffic.requests()).toEqual([
       ...LOGIN_REQUESTS,
       "POST /oauth2/token",

--- a/tests/e2e/svelte-app/src/App.svelte
+++ b/tests/e2e/svelte-app/src/App.svelte
@@ -6,13 +6,15 @@
   import ProtectedB from "./routes/ProtectedB.svelte";
 
   const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+  const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
+  const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
   const config = {
-    issuer: "http://localhost:9999/oauth2",
+    issuer: `http://localhost:${idpPort}/oauth2`,
     clientId: "e2e-test-app",
-    redirectUri: "http://localhost:5173/callback",
+    redirectUri: `http://localhost:${appPort}/callback`,
     scopes: ["openid", "profile", "email", "offline_access"],
-    postLogoutRedirectUri: "http://localhost:5173",
+    postLogoutRedirectUri: `http://localhost:${appPort}`,
   };
 
   let path = $state(window.location.pathname);

--- a/tests/e2e/vue-app/src/main.ts
+++ b/tests/e2e/vue-app/src/main.ts
@@ -8,6 +8,8 @@ import ProtectedA from "./views/ProtectedA.vue";
 import ProtectedB from "./views/ProtectedB.vue";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
+const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
 const router = createRouter({
   history: createWebHistory(),
@@ -23,11 +25,11 @@ const app = createApp(App);
 
 app.use(oidcPlugin, {
   config: {
-    issuer: "http://localhost:9999/oauth2",
+    issuer: `http://localhost:${idpPort}/oauth2`,
     clientId: "e2e-test-app",
-    redirectUri: "http://localhost:5173/callback",
+    redirectUri: `http://localhost:${appPort}/callback`,
     scopes: ["openid", "profile", "email", "offline_access"],
-    postLogoutRedirectUri: "http://localhost:5173",
+    postLogoutRedirectUri: `http://localhost:${appPort}`,
   },
   fetchProfile,
   onLogin(returnTo: string) {


### PR DESCRIPTION
## Summary
- Each E2E suite gets its own Autentico IdP port (10001-10008) and Vite dev server port (20001-20008) via env vars
- Test descriptions now include `[Framework]` prefix (e.g. `[React] OIDC Login Flow > ...`)
- `run-all.sh` supports `MAX_PARALLEL` (default 1, sequential). Use `MAX_PARALLEL=4 pnpm test:e2e` for parallel
- Autentico DB and log files moved to `.autentico/db/` and `.autentico/logs/`
- README updated with E2E test commands

## Test plan
- [x] Single suite passes with custom ports (`E2E_IDP_PORT=10001 E2E_APP_PORT=20001`)
- [x] Full sequential run passes (all 160 tests)
- [x] Parallel run with `MAX_PARALLEL=4` passes (all 160 tests, ~1m34s vs ~4m53s sequential)

🤖 Generated with [Claude Code](https://claude.com/claude-code)