### PR TITLE
feat: add security and protocol E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The core never calls `fetch` or touches browser APIs (except Web Crypto for PKCE
 Install the adapter for your framework:
 
 ```bash
-npm install oidc-js-react    # or oidc-js-vue, oidc-js-svelte, etc.
+npm install oidc-js-react    # or oidc-js-vue, oidc-js-svelte, etc
 ```
 
 Wrap your app with the provider:

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-angular",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Simple OIDC authentication for Angular. Signals, DI, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Simple OIDC authentication for JavaScript. Drop-in client with login, logout, token refresh, and zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -51,6 +51,7 @@ export class OidcClient {
   private discovery: OidcDiscovery | null = null;
   private subscribers = new Set<Subscriber>();
   private abortController: AbortController | null = null;
+  private refreshPromise: Promise<void> | null = null;
 
   private _state: AuthState = {
     user: null,
@@ -243,6 +244,18 @@ export class OidcClient {
    * @throws Error if no refresh token is available or discovery has not been fetched.
    */
   async refresh(): Promise<void> {
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = this.refreshInternal().finally(() => {
+      this.refreshPromise = null;
+    });
+
+    return this.refreshPromise;
+  }
+
+  private async refreshInternal(): Promise<void> {
     const refreshToken = this._state.tokens.refresh;
 
     if (!this.discovery || !refreshToken) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-core",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Zero-dependency OIDC/OAuth 2.0 functions for JavaScript. Pure, functional, works everywhere.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kasper/package.json
+++ b/packages/kasper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-kasper",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "description": "Simple OIDC authentication for Kasper.js. Signals, components, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-lit",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Simple OIDC authentication for Lit. Reactive controllers for login, logout, and token refresh with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-preact",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Simple OIDC authentication for Preact. Hooks, provider, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-react",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Simple OIDC authentication for React. Provider, hooks, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-solid",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Simple OIDC authentication for SolidJS. Signals, context, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-svelte",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Simple OIDC authentication for Svelte 5. Context, runes, and auth guards with zero dependencies.",
   "type": "module",
   "svelte": "./dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-vue",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "Simple OIDC authentication for Vue. Plugin, composables, and navigation guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/tests/e2e/angular-app/src/app/callback.component.ts
+++ b/tests/e2e/angular-app/src/app/callback.component.ts
@@ -1,8 +1,17 @@
-import { Component } from "@angular/core";
+import { Component, inject } from "@angular/core";
+import { AuthService } from "oidc-js-angular";
 
 @Component({
   selector: "app-callback",
   standalone: true,
-  template: `<div data-testid="auth-loading">Processing login...</div>`,
+  template: `
+    @if (auth.error()) {
+      <div data-testid="auth-error">Error: {{ auth.error()!.message }}</div>
+    } @else {
+      <div data-testid="auth-loading">Processing login...</div>
+    }
+  `,
 })
-export class CallbackComponent {}
+export class CallbackComponent {
+  readonly auth = inject(AuthService);
+}

--- a/tests/e2e/angular-app/src/app/home.component.ts
+++ b/tests/e2e/angular-app/src/app/home.component.ts
@@ -34,6 +34,7 @@ import { AuthService } from "oidc-js-angular";
         <div data-testid="expires-at">{{ auth.tokens().expiresAt ?? 'none' }}</div>
         <button data-testid="logout-button" (click)="logout()">Logout</button>
         <button data-testid="refresh-button" (click)="refresh()">Refresh</button>
+        <button data-testid="fetch-profile-button" (click)="doFetchProfile()">Fetch Profile</button>
         <nav>
           <a data-testid="link-protected-a" routerLink="/protected-a">Protected A</a>
           <a data-testid="link-protected-b" routerLink="/protected-b">Protected B</a>
@@ -60,5 +61,9 @@ export class HomeComponent {
 
   refresh() {
     this.auth.refresh().catch(() => {});
+  }
+
+  doFetchProfile() {
+    this.auth.fetchProfile().catch(() => {});
   }
 }

--- a/tests/e2e/kasper-app/src/components/Callback.kasper
+++ b/tests/e2e/kasper-app/src/components/Callback.kasper
@@ -1,9 +1,13 @@
 <template>
-  <div data-testid="auth-loading">Loading...</div>
+  <div @if="auth.error.value" data-testid="auth-error">Error: {{auth.error.value.message}}</div>
+  <div @else data-testid="auth-loading">Loading...</div>
 </template>
 
 <script>
 import { Component } from "kasper-js";
+import { useAuth } from "oidc-js-kasper";
 
-export class CallbackPage extends Component {}
+export class CallbackPage extends Component {
+  auth = useAuth();
+}
 </script>

--- a/tests/e2e/kasper-app/src/components/Home.kasper
+++ b/tests/e2e/kasper-app/src/components/Home.kasper
@@ -22,6 +22,7 @@
     <div data-testid="expires-at">{{auth.tokens.value.expiresAt ?? "none"}}</div>
     <button data-testid="logout-button" @on:click="auth.actions.logout()">Logout</button>
     <button data-testid="refresh-button" @on:click="handleRefresh()">Refresh</button>
+    <button data-testid="fetch-profile-button" @on:click="handleFetchProfile()">Fetch Profile</button>
     <nav>
       <a href="/protected-a" data-testid="link-protected-a" @on:click.prevent="goTo('/protected-a')">Protected A</a>
       <a href="/protected-b" data-testid="link-protected-b" @on:click.prevent="goTo('/protected-b')">Protected B</a>
@@ -43,6 +44,10 @@ export class HomePage extends Component {
 
   handleRefresh() {
     this.auth.actions.refresh().catch(() => {});
+  }
+
+  handleFetchProfile() {
+    this.auth.actions.fetchProfile().catch(() => {});
   }
 
   goTo(path) {

--- a/tests/e2e/lit-app/src/app-root.ts
+++ b/tests/e2e/lit-app/src/app-root.ts
@@ -54,6 +54,9 @@ export class AppRoot extends LitElement {
   render() {
     switch (this._path) {
       case "/callback":
+        if (this.auth.error) {
+          return html`<div data-testid="auth-error">Error: ${this.auth.error.message}</div>`;
+        }
         return html`<callback-page></callback-page>`;
       case "/protected-a":
         return html`<protected-a-page .auth=${this.auth} .navigate=${(p: string) => this.navigate(p)}></protected-a-page>`;

--- a/tests/e2e/lit-app/src/pages/home-page.ts
+++ b/tests/e2e/lit-app/src/pages/home-page.ts
@@ -54,6 +54,9 @@ export class HomePage extends LitElement {
         <button data-testid="refresh-button" @click=${() => this.auth.refresh().catch(() => {})}>
           Refresh
         </button>
+        <button data-testid="fetch-profile-button" @click=${() => this.auth.fetchProfile().catch(() => {})}>
+          Fetch Profile
+        </button>
         <nav>
           <a data-testid="link-protected-a" href="/protected-a" @click=${(e: Event) => { e.preventDefault(); this.navigate("/protected-a"); }}>Protected A</a>
           <a data-testid="link-protected-b" href="/protected-b" @click=${(e: Event) => { e.preventDefault(); this.navigate("/protected-b"); }}>Protected B</a>

--- a/tests/e2e/preact-app/src/pages/Callback.tsx
+++ b/tests/e2e/preact-app/src/pages/Callback.tsx
@@ -1,7 +1,13 @@
+import { useAuth } from "oidc-js-preact";
+
 interface CallbackPageProps {
   path?: string;
 }
 
 export function CallbackPage(_props: CallbackPageProps) {
+  const { error } = useAuth();
+  if (error) {
+    return <div data-testid="auth-error">Error: {error.message}</div>;
+  }
   return <div data-testid="auth-loading">Processing login...</div>;
 }

--- a/tests/e2e/preact-app/src/pages/Home.tsx
+++ b/tests/e2e/preact-app/src/pages/Home.tsx
@@ -48,6 +48,9 @@ export function HomePage(_props: HomePageProps) {
       <button data-testid="refresh-button" onClick={() => actions.refresh().catch(() => {})}>
         Refresh
       </button>
+      <button data-testid="fetch-profile-button" onClick={() => actions.fetchProfile().catch(() => {})}>
+        Fetch Profile
+      </button>
       <nav>
         <a data-testid="link-protected-a" href="/protected-a">Protected A</a>
         <a data-testid="link-protected-b" href="/protected-b">Protected B</a>

--- a/tests/e2e/react-app/src/App.tsx
+++ b/tests/e2e/react-app/src/App.tsx
@@ -45,6 +45,9 @@ function HomePage() {
       <button data-testid="refresh-button" onClick={() => actions.refresh().catch(() => {})}>
         Refresh
       </button>
+      <button data-testid="fetch-profile-button" onClick={() => actions.fetchProfile().catch(() => {})}>
+        Fetch Profile
+      </button>
       <nav>
         <Link data-testid="link-protected-a" to="/protected-a">Protected A</Link>
         <Link data-testid="link-protected-b" to="/protected-b">Protected B</Link>
@@ -54,6 +57,10 @@ function HomePage() {
 }
 
 function CallbackPage() {
+  const { error } = useAuth();
+  if (error) {
+    return <div data-testid="auth-error">Error: {error.message}</div>;
+  }
   return <div data-testid="auth-loading">Processing login...</div>;
 }
 

--- a/tests/e2e/solid-app/src/pages/Callback.tsx
+++ b/tests/e2e/solid-app/src/pages/Callback.tsx
@@ -1,3 +1,11 @@
+import { Show } from "solid-js";
+import { useAuth } from "oidc-js-solid";
+
 export function CallbackPage() {
-  return <div data-testid="auth-loading">Processing login...</div>;
+  const auth = useAuth();
+  return (
+    <Show when={!auth.error} fallback={<div data-testid="auth-error">Error: {auth.error!.message}</div>}>
+      <div data-testid="auth-loading">Processing login...</div>
+    </Show>
+  );
 }

--- a/tests/e2e/solid-app/src/pages/Home.tsx
+++ b/tests/e2e/solid-app/src/pages/Home.tsx
@@ -64,6 +64,12 @@ export function HomePage() {
           >
             Refresh
           </button>
+          <button
+            data-testid="fetch-profile-button"
+            onClick={() => auth.actions.fetchProfile().catch(() => {})}
+          >
+            Fetch Profile
+          </button>
           <nav>
             <A data-testid="link-protected-a" href="/protected-a">
               Protected A

--- a/tests/e2e/specs/login.spec.ts
+++ b/tests/e2e/specs/login.spec.ts
@@ -158,7 +158,7 @@ test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
 
   test("user.profile is null when fetchProfile is false", async ({ page }) => {
     const traffic = trackTraffic(page);
-    await page.goto("/");
+    await page.goto("/", { waitUntil: "networkidle" });
     await page.evaluate(() => localStorage.setItem("e2e-fetchProfile", "false"));
     await page.reload();
     await page.getByTestId("login-button").click();

--- a/tests/e2e/specs/login.spec.ts
+++ b/tests/e2e/specs/login.spec.ts
@@ -492,3 +492,158 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
     ]);
   });
 });
+
+test.describe(`[${FRAMEWORK}] Nonce Validation`, () => {
+  test("rejects token when nonce is tampered (replay protection)", async ({ page }) => {
+    const traffic = trackTraffic(page);
+
+    await page.addInitScript(() => {
+      const stored = sessionStorage.getItem("oidc-js:auth-state");
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        parsed.nonce = "tampered-nonce";
+        sessionStorage.setItem("oidc-js:auth-state", JSON.stringify(parsed));
+      }
+    });
+
+    await page.goto("/");
+    await page.getByTestId("login-button").click();
+    await page.waitForURL(idpPattern);
+    await page.fill('input[name="username"]', TEST_USER);
+    await page.fill('input[name="password"]', TEST_PASS);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(appPattern, { timeout: TIMEOUT });
+
+    await expect(page.getByTestId("auth-error")).toBeVisible({ timeout: TIMEOUT });
+    await expect(page.getByTestId("auth-error")).toContainText("nonce", { ignoreCase: true });
+
+    expect(traffic.sequence()).toEqual([
+      GET_WELLKNOWN,
+      NAV_AUTHORIZE,
+      GET_WELLKNOWN,
+      POST_TOKEN,
+    ]);
+  });
+});
+
+test.describe(`[${FRAMEWORK}] PKCE Security`, () => {
+  test("generates unique state, nonce, and code_challenge for each login", async ({ page }) => {
+    const authParams: URLSearchParams[] = [];
+    page.on("request", (req) => {
+      if (req.resourceType() !== "document") return;
+      const url = new URL(req.url());
+      if (url.origin === AUTENTICO_URL && url.pathname === "/oauth2/authorize") {
+        authParams.push(new URLSearchParams(url.search));
+      }
+    });
+
+    await login(page);
+    await page.getByTestId("logout-button").click();
+    await expect(page.getByTestId("unauthenticated")).toBeVisible({ timeout: TIMEOUT });
+
+    await login(page);
+
+    expect(authParams).toHaveLength(2);
+    expect(authParams[0].get("state")).toBeTruthy();
+    expect(authParams[1].get("state")).toBeTruthy();
+    expect(authParams[0].get("state")).not.toBe(authParams[1].get("state"));
+
+    expect(authParams[0].get("code_challenge")).toBeTruthy();
+    expect(authParams[1].get("code_challenge")).toBeTruthy();
+    expect(authParams[0].get("code_challenge")).not.toBe(authParams[1].get("code_challenge"));
+
+    expect(authParams[0].get("nonce")).toBeTruthy();
+    expect(authParams[1].get("nonce")).toBeTruthy();
+    expect(authParams[0].get("nonce")).not.toBe(authParams[1].get("nonce"));
+  });
+});
+
+test.describe(`[${FRAMEWORK}] Refresh Deduplication`, () => {
+  test("concurrent refresh calls produce only one token request", async ({ page }) => {
+    const traffic = trackTraffic(page);
+    await login(page);
+    const oldToken = await page.getByTestId("access-token-value").textContent();
+
+    await page.evaluate(() => {
+      const btn = document.querySelector('[data-testid="refresh-button"]')!;
+      btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await expect(page.getByTestId("access-token-value")).not.toHaveText(oldToken!, { timeout: TIMEOUT });
+
+    const postLoginTokenRequests = traffic.requests()
+      .slice(LOGIN_REQUESTS.length)
+      .filter((r) => r === POST_TOKEN);
+    expect(postLoginTokenRequests).toHaveLength(1);
+  });
+});
+
+test.describe(`[${FRAMEWORK}] Token Revocation`, () => {
+  test("handles revoked access token gracefully on userinfo fetch", async ({ page }) => {
+    const traffic = trackTraffic(page);
+    await login(page);
+
+    const accessToken = await page.getByTestId("access-token-value").textContent();
+    await revokeToken(accessToken!, "access_token");
+
+    await page.getByTestId("fetch-profile-button").click();
+    await page.waitForTimeout(1000);
+
+    await expect(page.getByTestId("authenticated")).toBeVisible();
+
+    const postLoginRequests = traffic.requests().slice(LOGIN_REQUESTS.length);
+    expect(postLoginRequests).toContain(GET_USERINFO);
+  });
+
+  test("manual refresh obtains new tokens after normal expiry", async ({ page }) => {
+    const traffic = trackTraffic(page);
+    await login(page);
+
+    const oldToken = await page.getByTestId("access-token-value").textContent();
+    await page.getByTestId("refresh-button").click();
+    await expect(page.getByTestId("access-token-value")).not.toHaveText(oldToken!, { timeout: TIMEOUT });
+
+    await page.getByTestId("fetch-profile-button").click();
+    await page.waitForTimeout(1000);
+    await expect(page.getByTestId("authenticated")).toBeVisible();
+
+    const postLoginSequence = traffic.sequence().slice(LOGIN_SEQUENCE.length);
+    expect(postLoginSequence).toEqual([
+      POST_TOKEN,
+      GET_USERINFO,
+      GET_USERINFO,
+    ]);
+  });
+});
+
+test.describe(`[${FRAMEWORK}] Concurrent Tabs`, () => {
+  test("concurrent logins in separate tabs do not interfere", async ({ page, context }) => {
+    const page2 = await context.newPage();
+
+    await page.goto("/");
+    await page.getByTestId("login-button").click();
+    await page.waitForURL(idpPattern);
+
+    await page2.goto(`http://localhost:${APP_PORT}/`);
+    await page2.getByTestId("login-button").click();
+    await page2.waitForURL(idpPattern);
+
+    await page.fill('input[name="username"]', TEST_USER);
+    await page.fill('input[name="password"]', TEST_PASS);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(appPattern, { timeout: TIMEOUT });
+    await expect(page.getByTestId("authenticated")).toBeVisible({ timeout: TIMEOUT });
+
+    await page2.fill('input[name="username"]', TEST_USER);
+    await page2.fill('input[name="password"]', TEST_PASS);
+    await page2.click('button[type="submit"]');
+    await page2.waitForURL(appPattern, { timeout: TIMEOUT });
+    await expect(page2.getByTestId("authenticated")).toBeVisible({ timeout: TIMEOUT });
+
+    await expect(page.getByTestId("access-token")).toHaveText("present");
+    await expect(page2.getByTestId("access-token")).toHaveText("present");
+
+    await page2.close();
+  });
+});

--- a/tests/e2e/svelte-app/src/routes/Callback.svelte
+++ b/tests/e2e/svelte-app/src/routes/Callback.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
-  // The callback page simply shows a loading indicator while
-  // the AuthProvider processes the authorization code exchange.
+  import { getAuthContext } from "oidc-js-svelte";
+
+  const auth = getAuthContext();
 </script>
 
-<div data-testid="auth-loading">Processing login...</div>
+{#if auth.error}
+  <div data-testid="auth-error">Error: {auth.error.message}</div>
+{:else}
+  <div data-testid="auth-loading">Processing login...</div>
+{/if}

--- a/tests/e2e/svelte-app/src/routes/Home.svelte
+++ b/tests/e2e/svelte-app/src/routes/Home.svelte
@@ -48,6 +48,9 @@
     <button data-testid="refresh-button" onclick={() => auth.actions.refresh().catch(() => {})}>
       Refresh
     </button>
+    <button data-testid="fetch-profile-button" onclick={() => auth.actions.fetchProfile().catch(() => {})}>
+      Fetch Profile
+    </button>
     <nav>
       <a href="/protected-a" data-testid="link-protected-a" onclick={(e) => goTo(e, "/protected-a")}>Protected A</a>
       <a href="/protected-b" data-testid="link-protected-b" onclick={(e) => goTo(e, "/protected-b")}>Protected B</a>

--- a/tests/e2e/vue-app/src/views/Callback.vue
+++ b/tests/e2e/vue-app/src/views/Callback.vue
@@ -1,3 +1,10 @@
+<script setup lang="ts">
+import { useAuth } from "oidc-js-vue";
+
+const { error } = useAuth();
+</script>
+
 <template>
-  <div data-testid="auth-loading">Processing login...</div>
+  <div v-if="error" data-testid="auth-error">Error: {{ error.message }}</div>
+  <div v-else data-testid="auth-loading">Processing login...</div>
 </template>

--- a/tests/e2e/vue-app/src/views/Home.vue
+++ b/tests/e2e/vue-app/src/views/Home.vue
@@ -28,6 +28,7 @@ const { user, isAuthenticated, isLoading, error, tokens, actions } = useAuth();
     <div data-testid="expires-at">{{ tokens.expiresAt ?? "none" }}</div>
     <button data-testid="logout-button" @click="actions.logout()">Logout</button>
     <button data-testid="refresh-button" @click="actions.refresh().catch(() => {})">Refresh</button>
+    <button data-testid="fetch-profile-button" @click="actions.fetchProfile().catch(() => {})">Fetch Profile</button>
     <nav>
       <router-link data-testid="link-protected-a" to="/protected-a">Protected A</router-link>
       <router-link data-testid="link-protected-b" to="/protected-b">Protected B</router-link>


### PR DESCRIPTION
## Summary
- Add 6 new E2E tests: nonce tampering (replay protection), PKCE uniqueness, refresh deduplication, access token revocation handling, refresh+fetchProfile recovery, and concurrent tab isolation
- Fix refresh token deduplication in `OidcClient` — concurrent `refresh()` calls now return the same in-flight promise instead of firing duplicate requests
- Update all 8 framework callback components to surface `auth-error` when init fails (was showing "Processing login..." forever)
- Add `fetchProfile` button to all test apps for token revocation testing
- Bump all packages to 1.0.4

## Test plan
- [x] All 26 tests pass across all 8 frameworks (208 total)
- [x] Core and client unit tests pass
- [x] Ran full suite with `MAX_PARALLEL=4` — all green
- [x] Refresh dedup verified: two synchronous clicks produce exactly one `POST /oauth2/token`

🤖 Generated with [Claude Code](https://claude.com/claude-code)