### PR TITLE
feat: standardize tokenExpirationBuffer across framework adapters

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-angular",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Simple OIDC authentication for Angular. Signals, DI, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/angular/src/auth.guard.ts
+++ b/packages/angular/src/auth.guard.ts
@@ -1,9 +1,15 @@
 import { inject } from "@angular/core";
 import type { CanActivateFn } from "@angular/router";
+import { isExpiredAt } from "oidc-js-core";
 import { AuthService } from "./auth.service.js";
 
+export interface AuthGuardOptions {
+  /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
+  tokenExpirationBuffer?: number;
+}
+
 /**
- * Functional route guard that protects routes behind authentication.
+ * Creates a functional route guard that protects routes behind authentication.
  *
  * Behavior:
  * - If the auth service is still loading, waits until initialization completes.
@@ -15,40 +21,41 @@ import { AuthService } from "./auth.service.js";
  * @example
  * ```typescript
  * const routes: Routes = [
- *   { path: 'protected', component: ProtectedComponent, canActivate: [authGuard] },
+ *   { path: 'protected', component: ProtectedComponent, canActivate: [createAuthGuard()] },
  * ];
  * ```
  */
-export const authGuard: CanActivateFn = async (route, state) => {
-  const auth = inject(AuthService);
+export function createAuthGuard(options?: AuthGuardOptions): CanActivateFn {
+  return async (route, state) => {
+    const auth = inject(AuthService);
 
-  // Wait for initialization to complete
-  if (auth.isLoading()) {
-    await waitForLoading(auth);
-  }
-
-  const tokens = auth.tokens();
-  const isExpired = tokens.expiresAt !== null && tokens.expiresAt <= Date.now();
-
-  // Authenticated and not expired — allow
-  if (auth.isAuthenticated() && !isExpired) {
-    return true;
-  }
-
-  // Expired but has refresh token — attempt refresh
-  if (auth.isAuthenticated() && isExpired && tokens.refresh) {
-    try {
-      await auth.refresh();
-      return true;
-    } catch {
-      // Refresh failed — fall through to login redirect
+    if (auth.isLoading()) {
+      await waitForLoading(auth);
     }
-  }
 
-  // Not authenticated or refresh failed — redirect to login
-  await auth.login({ returnTo: state.url });
-  return false;
-};
+    const tokens = auth.tokens();
+    const isExpired = isExpiredAt(tokens.expiresAt, options?.tokenExpirationBuffer);
+
+    if (auth.isAuthenticated() && !isExpired) {
+      return true;
+    }
+
+    if (auth.isAuthenticated() && isExpired && tokens.refresh) {
+      try {
+        await auth.refresh();
+        return true;
+      } catch {
+        // Refresh failed — fall through to login redirect
+      }
+    }
+
+    await auth.login({ returnTo: state.url });
+    return false;
+  };
+}
+
+/** Pre-built auth guard using default options. Use {@link createAuthGuard} for custom configuration. */
+export const authGuard: CanActivateFn = createAuthGuard();
 
 /**
  * Returns a promise that resolves when the auth service finishes loading.

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,6 +1,6 @@
 export { AuthService, AUTH_OPTIONS } from "./auth.service.js";
 export { provideAuth } from "./provide-auth.js";
-export { authGuard } from "./auth.guard.js";
+export { authGuard, createAuthGuard, type AuthGuardOptions } from "./auth.guard.js";
 
 export type {
   AuthProviderOptions,

--- a/packages/angular/src/tests/auth.guard.test.ts
+++ b/packages/angular/src/tests/auth.guard.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 
 const { mockAuthService } = vi.hoisted(() => {
   const mockAuthService = {
@@ -53,7 +54,7 @@ describe("authGuard", () => {
       access: "token",
       id: null,
       refresh: null,
-      expiresAt: Date.now() + 3600_000,
+      expiresAt: nowSeconds() + 3600,
     });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -85,7 +86,7 @@ describe("authGuard", () => {
       access: "expired",
       id: null,
       refresh: "rt",
-      expiresAt: Date.now() - 60_000,
+      expiresAt: nowSeconds() - 60,
     });
     mockAuthService.refresh.mockResolvedValue(undefined);
 
@@ -105,7 +106,7 @@ describe("authGuard", () => {
       access: "expired",
       id: null,
       refresh: "rt",
-      expiresAt: Date.now() - 60_000,
+      expiresAt: nowSeconds() - 60,
     });
     mockAuthService.refresh.mockRejectedValue(new Error("expired"));
 
@@ -128,7 +129,7 @@ describe("authGuard", () => {
       access: "token",
       id: null,
       refresh: null,
-      expiresAt: Date.now() + 3600_000,
+      expiresAt: nowSeconds() + 3600,
     });
 
     setTimeout(() => {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Simple OIDC authentication for JavaScript. Drop-in client with login, logout, token refresh, and zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -26,15 +26,15 @@ type Subscriber = (state: AuthState) => void;
 const EMPTY_TOKENS: AuthTokens = { access: null, id: null, refresh: null, expiresAt: null };
 
 /**
- * Extracts the `exp` claim from an access token JWT and converts it to milliseconds.
+ * Extracts the `exp` claim from an access token JWT.
  *
  * @param accessToken - A JWT access token string.
- * @returns The expiration time in milliseconds, or null if the token cannot be decoded.
+ * @returns The expiration time as a Unix timestamp in seconds, or null if the token cannot be decoded.
  */
 function extractExpiresAt(accessToken: string): number | null {
   try {
     const payload = decodeJwtPayload(accessToken);
-    if (typeof payload.exp === "number") return payload.exp * 1000;
+    if (typeof payload.exp === "number") return payload.exp;
   } catch { /* malformed JWT */ }
   return null;
 }

--- a/packages/client/src/tests/client.test.ts
+++ b/packages/client/src/tests/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import { OidcClient } from "../client.js";
 import type { OidcClientConfig } from "../types.js";
 
@@ -27,14 +28,14 @@ function makeJwt(payload: Record<string, unknown>): string {
 }
 
 const TOKEN_RESPONSE = {
-  access_token: makeJwt({ sub: "user-1", exp: Math.floor(Date.now() / 1000) + 3600 }),
+  access_token: makeJwt({ sub: "user-1", exp: nowSeconds() + 3600 }),
   token_type: "Bearer",
   id_token: makeJwt({
     sub: "user-1",
     iss: "https://auth.example.com",
     aud: "my-app",
-    exp: Math.floor(Date.now() / 1000) + 3600,
-    iat: Math.floor(Date.now() / 1000),
+    exp: nowSeconds() + 3600,
+    iat: nowSeconds(),
     nonce: "test-nonce",
   }),
   refresh_token: "rt_123",

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -40,7 +40,7 @@ export interface AuthTokens {
   id: string | null;
   /** The refresh token string, or null if not returned. */
   refresh: string | null;
-  /** Access token expiration as a Unix timestamp in milliseconds, or null if unknown. */
+  /** Access token expiration as a Unix timestamp in seconds, or null if unknown. */
   expiresAt: number | null;
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-core",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Zero-dependency OIDC/OAuth 2.0 functions for JavaScript. Pure, functional, works everywhere.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,7 @@ export { buildIntrospectRequest, parseIntrospectResponse } from "./introspect.js
 export { buildRevocationRequest } from "./revocation.js";
 export { buildLogoutUrl } from "./logout.js";
 export { decodeJwtPayload, parseIdTokenClaims } from "./jwt.js";
-export { computeExpiresAt, isTokenExpired, timeUntilExpiry } from "./token-utils.js";
+export { nowSeconds, computeExpiresAt, timeUntilExpiry, isExpiredAt, DEFAULT_TOKEN_EXPIRATION_BUFFER } from "./token-utils.js";
 export { buildClientAuthHeaders } from "./auth.js";
 
 export type {

--- a/packages/core/src/tests/token-utils.test.ts
+++ b/packages/core/src/tests/token-utils.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { computeExpiresAt, isTokenExpired, timeUntilExpiry } from "../token-utils.js";
-import type { TokenSet } from "../types.js";
+import { nowSeconds, computeExpiresAt, timeUntilExpiry, isExpiredAt, DEFAULT_TOKEN_EXPIRATION_BUFFER } from "../token-utils.js";
 
 describe("computeExpiresAt", () => {
   beforeEach(() => {
@@ -13,14 +12,13 @@ describe("computeExpiresAt", () => {
   });
 
   it("returns absolute timestamp from relative expires_in", () => {
-    const now = Math.floor(Date.now() / 1000);
     const result = computeExpiresAt(3600);
-
-    expect(result).toBe(now + 3600);
+    expect(result).toBe(nowSeconds() + 3600);
   });
 });
 
-describe("isTokenExpired", () => {
+describe("isExpiredAt", () => {
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
@@ -30,49 +28,41 @@ describe("isTokenExpired", () => {
     vi.useRealTimers();
   });
 
-  it("returns false for future expiry", () => {
-    const tokenSet: TokenSet = {
-      access_token: "at",
-      token_type: "Bearer",
-      expires_at: Math.floor(Date.now() / 1000) + 3600,
-    };
+  it("returns false when expiresAt is null", () => {
+    expect(isExpiredAt(null)).toBe(false);
+  });
 
-    expect(isTokenExpired(tokenSet)).toBe(false);
+  it("returns false for future expiry beyond buffer", () => {
+    expect(isExpiredAt(nowSeconds() + 60)).toBe(false);
   });
 
   it("returns true for past expiry", () => {
-    const tokenSet: TokenSet = {
-      access_token: "at",
-      token_type: "Bearer",
-      expires_at: Math.floor(Date.now() / 1000) - 60,
-    };
-
-    expect(isTokenExpired(tokenSet)).toBe(true);
+    expect(isExpiredAt(nowSeconds() - 1)).toBe(true);
   });
 
-  it("returns false when expires_at is undefined", () => {
-    const tokenSet: TokenSet = {
-      access_token: "at",
-      token_type: "Bearer",
-    };
-
-    expect(isTokenExpired(tokenSet)).toBe(false);
+  it("returns true when within default buffer window", () => {
+    expect(isExpiredAt(nowSeconds() + 15)).toBe(true);
   });
 
-  it("accounts for clockSkewSeconds", () => {
-    const now = Math.floor(Date.now() / 1000);
-    const tokenSet: TokenSet = {
-      access_token: "at",
-      token_type: "Bearer",
-      expires_at: now + 30,
-    };
+  it("uses custom buffer", () => {
+    const expiresAt = nowSeconds() + 5;
+    expect(isExpiredAt(expiresAt, 10)).toBe(true);
+    expect(isExpiredAt(expiresAt, 2)).toBe(false);
+  });
 
-    expect(isTokenExpired(tokenSet, 0)).toBe(false);
-    expect(isTokenExpired(tokenSet, 60)).toBe(true);
+  it("returns false at exact boundary with zero buffer", () => {
+    expect(isExpiredAt(nowSeconds() + 1, 0)).toBe(false);
+  });
+
+  it("defaults to DEFAULT_TOKEN_EXPIRATION_BUFFER (30s)", () => {
+    expect(DEFAULT_TOKEN_EXPIRATION_BUFFER).toBe(30);
+    expect(isExpiredAt(nowSeconds() + 29)).toBe(true);
+    expect(isExpiredAt(nowSeconds() + 31)).toBe(false);
   });
 });
 
 describe("timeUntilExpiry", () => {
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
@@ -83,31 +73,14 @@ describe("timeUntilExpiry", () => {
   });
 
   it("returns positive seconds for valid token", () => {
-    const tokenSet: TokenSet = {
-      access_token: "at",
-      token_type: "Bearer",
-      expires_at: Math.floor(Date.now() / 1000) + 1800,
-    };
-
-    expect(timeUntilExpiry(tokenSet)).toBe(1800);
+    expect(timeUntilExpiry(nowSeconds() + 60)).toBe(60);
   });
 
   it("returns 0 for expired token", () => {
-    const tokenSet: TokenSet = {
-      access_token: "at",
-      token_type: "Bearer",
-      expires_at: Math.floor(Date.now() / 1000) - 300,
-    };
-
-    expect(timeUntilExpiry(tokenSet)).toBe(0);
+    expect(timeUntilExpiry(nowSeconds() - 5)).toBe(0);
   });
 
-  it("returns Infinity when expires_at is undefined", () => {
-    const tokenSet: TokenSet = {
-      access_token: "at",
-      token_type: "Bearer",
-    };
-
-    expect(timeUntilExpiry(tokenSet)).toBe(Infinity);
+  it("returns Infinity when expiresAt is null", () => {
+    expect(timeUntilExpiry(null)).toBe(Infinity);
   });
 });

--- a/packages/core/src/tests/token.test.ts
+++ b/packages/core/src/tests/token.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { buildTokenRequest, buildRefreshRequest, parseTokenResponse } from "../token.js";
+import { nowSeconds } from "../token-utils.js";
 import { OidcError } from "../errors.js";
 import type { OidcDiscovery, OidcConfig } from "../types.js";
 
@@ -125,7 +126,7 @@ describe("parseTokenResponse", () => {
     expect(result.token_type).toBe("Bearer");
     expect(result.expires_in).toBe(3600);
     expect(result.refresh_token).toBe("rt_123");
-    expect(result.expires_at).toBe(Math.floor(Date.now() / 1000) + 3600);
+    expect(result.expires_at).toBe(nowSeconds() + 3600);
   });
 
   it("defaults token_type to Bearer when missing", () => {

--- a/packages/core/src/token-utils.ts
+++ b/packages/core/src/token-utils.ts
@@ -1,4 +1,10 @@
-import type { TokenSet } from "./types.js";
+/** Default token expiration buffer in seconds (30 seconds). */
+export const DEFAULT_TOKEN_EXPIRATION_BUFFER = 30;
+
+/** Returns the current time as a Unix timestamp in seconds. */
+export function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}
 
 /**
  * Converts a relative `expires_in` value (seconds from now) to an absolute Unix timestamp.
@@ -7,35 +13,30 @@ import type { TokenSet } from "./types.js";
  * @returns Absolute expiry time as a Unix timestamp in seconds.
  */
 export function computeExpiresAt(expiresIn: number): number {
-  return Math.floor(Date.now() / 1000) + expiresIn;
+  return nowSeconds() + expiresIn;
 }
 
 /**
- * Checks whether the access token in a {@link TokenSet} has expired.
- * Returns `false` if no `expires_at` is set (the token is treated as non-expiring).
+ * Checks whether a token has expired given an absolute expiration timestamp in seconds.
+ * Returns `false` if `expiresAt` is null (the token is treated as non-expiring).
  *
- * @param tokenSet - The token set to check.
- * @param clockSkewSeconds - Optional allowance for clock drift between client and server (defaults to 0).
- * @returns `true` if the current time is at or past the adjusted expiry time.
+ * @param expiresAt - Expiration time as a Unix timestamp in seconds, or null.
+ * @param bufferSeconds - Buffer in seconds subtracted from expiry to account for clock skew and network latency.
+ * @returns `true` if the current time is at or past the buffered expiry time.
  */
-export function isTokenExpired(tokenSet: TokenSet, clockSkewSeconds: number = 0): boolean {
-  if (tokenSet.expires_at === undefined) {
-    return false;
-  }
-  return Math.floor(Date.now() / 1000) >= tokenSet.expires_at - clockSkewSeconds;
+export function isExpiredAt(expiresAt: number | null, bufferSeconds: number = DEFAULT_TOKEN_EXPIRATION_BUFFER): boolean {
+  if (expiresAt === null) return false;
+  return nowSeconds() >= expiresAt - bufferSeconds;
 }
 
 /**
  * Returns the number of seconds remaining until the token expires.
- * Returns `Infinity` if no `expires_at` is set, or `0` if the token is already expired.
+ * Returns `Infinity` if `expiresAt` is null, or `0` if the token is already expired.
  *
- * @param tokenSet - The token set to inspect.
+ * @param expiresAt - Expiration time as a Unix timestamp in seconds, or null.
  * @returns Seconds remaining until expiry (never negative).
  */
-export function timeUntilExpiry(tokenSet: TokenSet): number {
-  if (tokenSet.expires_at === undefined) {
-    return Infinity;
-  }
-  const remaining = tokenSet.expires_at - Math.floor(Date.now() / 1000);
-  return Math.max(0, remaining);
+export function timeUntilExpiry(expiresAt: number | null): number {
+  if (expiresAt === null) return Infinity;
+  return Math.max(0, expiresAt - nowSeconds());
 }

--- a/packages/core/src/token.ts
+++ b/packages/core/src/token.ts
@@ -2,6 +2,7 @@ import type { OidcConfig, OidcDiscovery, HttpRequest, TokenSet } from "./types.j
 import { OidcError } from "./errors.js";
 import { decodeJwtPayload } from "./jwt.js";
 import { buildClientAuthHeaders } from "./auth.js";
+import { computeExpiresAt } from "./token-utils.js";
 
 /**
  * Builds an HTTP request to exchange an authorization code for tokens (RFC 6749 §4.1.3).
@@ -117,7 +118,7 @@ export function parseTokenResponse(data: unknown, expectedNonce?: string): Token
 
   // Compute absolute expiry timestamp
   if (tokenSet.expires_in !== undefined) {
-    tokenSet.expires_at = Math.floor(Date.now() / 1000) + tokenSet.expires_in;
+    tokenSet.expires_at = computeExpiresAt(tokenSet.expires_in);
   }
 
   return tokenSet;

--- a/packages/kasper/package.json
+++ b/packages/kasper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-kasper",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Simple OIDC authentication for Kasper.js. Signals, components, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kasper/src/require-auth.ts
+++ b/packages/kasper/src/require-auth.ts
@@ -1,10 +1,12 @@
 import { Component } from "kasper-js";
 import type { LoginOptions } from "oidc-js";
+import { isExpiredAt } from "oidc-js-core";
 import { useAuth } from "./context.js";
 
 interface RequireAuthArgs {
   autoRefresh?: boolean;
   loginOptions?: LoginOptions;
+  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -28,9 +30,7 @@ export class RequireAuth extends Component<RequireAuthArgs> {
 
   _ready(): boolean {
     const auth = useAuth();
-    const isExpired =
-      auth.tokens.value.expiresAt !== null &&
-      auth.tokens.value.expiresAt <= Date.now();
+    const isExpired = isExpiredAt(auth.tokens.value.expiresAt, this.args.tokenExpirationBuffer);
     return (
       !auth.isLoading.value && auth.isAuthenticated.value && !isExpired
     );
@@ -41,9 +41,7 @@ export class RequireAuth extends Component<RequireAuthArgs> {
     const autoRefresh = this.args.autoRefresh ?? true;
 
     this.effect(() => {
-      const isExpired =
-        auth.tokens.value.expiresAt !== null &&
-        auth.tokens.value.expiresAt <= Date.now();
+      const isExpired = isExpiredAt(auth.tokens.value.expiresAt, this.args.tokenExpirationBuffer);
       const needsAuth = !auth.isAuthenticated.value || isExpired;
 
       if (!needsAuth) {

--- a/packages/kasper/src/tests/context.test.ts
+++ b/packages/kasper/src/tests/context.test.ts
@@ -121,7 +121,7 @@ describe("_initAuth", () => {
       isAuthenticated: true,
       isLoading: false,
       error: null,
-      tokens: { access: "at_123", id: "id_456", refresh: "rt_789", expiresAt: 9999999999999 },
+      tokens: { access: "at_123", id: "id_456", refresh: "rt_789", expiresAt: 9999999999 },
     });
 
     const auth = useAuth();

--- a/packages/kasper/src/tests/require-auth.test.ts
+++ b/packages/kasper/src/tests/require-auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import type { AuthContextValue } from "../types.js";
 
 type MutableAuth = { -readonly [K in keyof AuthContextValue]: AuthContextValue[K] };
@@ -91,7 +92,7 @@ describe("RequireAuth", () => {
             access: "token",
             id: null,
             refresh: null,
-            expiresAt: Date.now() + 3600_000,
+            expiresAt: nowSeconds() + 3600,
           },
         } as AuthContextValue["tokens"],
       });
@@ -129,7 +130,7 @@ describe("RequireAuth", () => {
             access: "expired",
             id: null,
             refresh: null,
-            expiresAt: Date.now() - 60_000,
+            expiresAt: nowSeconds() - 60,
           },
         } as AuthContextValue["tokens"],
       });
@@ -188,7 +189,7 @@ describe("RequireAuth", () => {
             access: "token",
             id: null,
             refresh: null,
-            expiresAt: Date.now() + 3600_000,
+            expiresAt: nowSeconds() + 3600,
           },
         } as AuthContextValue["tokens"],
         actions,
@@ -234,7 +235,7 @@ describe("RequireAuth", () => {
             access: "expired",
             id: null,
             refresh: "rt",
-            expiresAt: Date.now() - 60_000,
+            expiresAt: nowSeconds() - 60,
           },
         } as AuthContextValue["tokens"],
         actions,

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-lit",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Simple OIDC authentication for Lit. Reactive controllers for login, logout, and token refresh with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/lit/src/require-auth.ts
+++ b/packages/lit/src/require-auth.ts
@@ -1,6 +1,7 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 import type { AuthController } from "./auth-controller.js";
 import type { LoginOptions } from "oidc-js";
+import { isExpiredAt } from "oidc-js-core";
 
 /**
  * Options for the {@link RequireAuthController}.
@@ -12,6 +13,8 @@ export interface RequireAuthOptions {
   autoRefresh?: boolean;
   /** Additional options passed to the login redirect if authentication is required. */
   loginOptions?: LoginOptions;
+  /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
+  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -52,6 +55,7 @@ export class RequireAuthController implements ReactiveController {
   private auth: AuthController;
   private autoRefresh: boolean;
   private loginOptions?: LoginOptions;
+  private tokenExpirationBuffer?: number;
   private refreshAttempted = false;
 
   /**
@@ -65,6 +69,7 @@ export class RequireAuthController implements ReactiveController {
     this.auth = options.auth;
     this.autoRefresh = options.autoRefresh ?? true;
     this.loginOptions = options.loginOptions;
+    this.tokenExpirationBuffer = options.tokenExpirationBuffer;
     host.addController(this);
   }
 
@@ -74,7 +79,7 @@ export class RequireAuthController implements ReactiveController {
    */
   get authorized(): boolean {
     const { isAuthenticated, isLoading, tokens } = this.auth;
-    const isExpired = tokens.expiresAt !== null && tokens.expiresAt <= Date.now();
+    const isExpired = isExpiredAt(tokens.expiresAt, this.tokenExpirationBuffer);
     return isAuthenticated && !isExpired && !isLoading;
   }
 
@@ -94,7 +99,7 @@ export class RequireAuthController implements ReactiveController {
    */
   hostUpdated(): void {
     const { isAuthenticated, isLoading, tokens } = this.auth;
-    const isExpired = tokens.expiresAt !== null && tokens.expiresAt <= Date.now();
+    const isExpired = isExpiredAt(tokens.expiresAt, this.tokenExpirationBuffer);
     const needsAuth = !isAuthenticated || isExpired;
 
     if (!needsAuth) {

--- a/packages/lit/src/tests/require-auth.test.ts
+++ b/packages/lit/src/tests/require-auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import type { ReactiveControllerHost } from "lit";
 import { RequireAuthController } from "../require-auth.js";
 import type { AuthController } from "../auth-controller.js";
@@ -60,7 +61,7 @@ describe("RequireAuthController", () => {
     const auth = makeAuth({
       isAuthenticated: true,
       isLoading: false,
-      tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 },
+      tokens: { access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 },
     });
     const guard = new RequireAuthController(host, { auth });
 
@@ -71,7 +72,7 @@ describe("RequireAuthController", () => {
     const host = createMockHost();
     const auth = makeAuth({
       isAuthenticated: true,
-      tokens: { access: "expired", id: null, refresh: null, expiresAt: Date.now() - 60_000 },
+      tokens: { access: "expired", id: null, refresh: null, expiresAt: nowSeconds() - 60 },
     });
     const guard = new RequireAuthController(host, { auth });
 
@@ -83,7 +84,7 @@ describe("RequireAuthController", () => {
     const auth = makeAuth({
       isAuthenticated: true,
       isLoading: true,
-      tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 },
+      tokens: { access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 },
     });
     const guard = new RequireAuthController(host, { auth });
 
@@ -120,7 +121,7 @@ describe("RequireAuthController", () => {
     const host = createMockHost();
     const auth = makeAuth({
       isAuthenticated: true,
-      tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 },
+      tokens: { access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 },
     });
     const guard = new RequireAuthController(host, { auth });
 
@@ -134,7 +135,7 @@ describe("RequireAuthController", () => {
     const host = createMockHost();
     const auth = makeAuth({
       isAuthenticated: true,
-      tokens: { access: "expired", id: null, refresh: "rt", expiresAt: Date.now() - 60_000 },
+      tokens: { access: "expired", id: null, refresh: "rt", expiresAt: nowSeconds() - 60 },
       refresh: vi.fn().mockResolvedValue(undefined),
     });
     const guard = new RequireAuthController(host, { auth });

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-preact",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Simple OIDC authentication for Preact. Hooks, provider, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/preact/src/auth-required.tsx
+++ b/packages/preact/src/auth-required.tsx
@@ -2,12 +2,14 @@ import { useEffect, useRef } from "preact/hooks";
 import type { ComponentChildren } from "preact";
 import { useAuth } from "./context.js";
 import type { LoginOptions } from "oidc-js";
+import { isExpiredAt } from "oidc-js-core";
 
 interface RequireAuthProps {
   children: ComponentChildren;
   fallback?: ComponentChildren;
   autoRefresh?: boolean;
   loginOptions?: LoginOptions;
+  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -24,11 +26,12 @@ export function RequireAuth({
   fallback = null,
   autoRefresh = true,
   loginOptions,
+  tokenExpirationBuffer,
 }: RequireAuthProps) {
   const { isAuthenticated, isLoading, tokens, actions } = useAuth();
   const refreshAttempted = useRef(false);
 
-  const isExpired = tokens.expiresAt !== null && tokens.expiresAt <= Date.now();
+  const isExpired = isExpiredAt(tokens.expiresAt, tokenExpirationBuffer);
   const needsAuth = !isAuthenticated || isExpired;
 
   useEffect(() => {

--- a/packages/preact/src/tests/auth-required.test.tsx
+++ b/packages/preact/src/tests/auth-required.test.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck - Preact's h() types require children in props but we pass them as 3rd arg
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import { render, screen, cleanup, waitFor } from "@testing-library/preact";
 import { h } from "preact";
 import { RequireAuth } from "../auth-required.js";
@@ -50,7 +51,7 @@ describe("RequireAuth", () => {
     mockUseAuth.mockReturnValue(
       makeAuth({
         isAuthenticated: true,
-        tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 },
+        tokens: { access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 },
       }),
     );
 
@@ -113,7 +114,7 @@ describe("RequireAuth", () => {
     mockUseAuth.mockReturnValue(
       makeAuth({
         isAuthenticated: true,
-        tokens: { access: "expired", id: null, refresh: "valid-refresh", expiresAt: Date.now() - 60_000 },
+        tokens: { access: "expired", id: null, refresh: "valid-refresh", expiresAt: nowSeconds() - 60 },
         actions,
       }),
     );
@@ -131,7 +132,7 @@ describe("RequireAuth", () => {
     mockUseAuth.mockReturnValue(
       makeAuth({
         isAuthenticated: true,
-        tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 },
+        tokens: { access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 },
       }),
     );
 

--- a/packages/preact/src/tests/context.test.tsx
+++ b/packages/preact/src/tests/context.test.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck - Preact's h() types require children in props but we pass them as 3rd arg
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import { render, screen, waitFor, cleanup, act } from "@testing-library/preact";
 import { h } from "preact";
 import { AuthProvider, useAuth } from "../context.js";
@@ -36,8 +37,8 @@ const TOKEN_RESPONSE = {
     sub: "user-1",
     iss: "https://auth.example.com",
     aud: "my-app",
-    exp: Math.floor(Date.now() / 1000) + 3600,
-    iat: Math.floor(Date.now() / 1000),
+    exp: nowSeconds() + 3600,
+    iat: nowSeconds(),
     nonce: "test-nonce",
   }),
   refresh_token: "rt_123",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-react",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Simple OIDC authentication for React. Provider, hooks, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/src/auth-required.tsx
+++ b/packages/react/src/auth-required.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef, type ReactNode } from "react";
 import { useAuth } from "./context.js";
 import type { LoginOptions } from "oidc-js";
+import { isExpiredAt } from "oidc-js-core";
 
 interface RequireAuthProps {
   children: ReactNode;
   fallback?: ReactNode;
   autoRefresh?: boolean;
   loginOptions?: LoginOptions;
+  tokenExpirationBuffer?: number;
 }
 
 export function RequireAuth({
@@ -14,11 +16,12 @@ export function RequireAuth({
   fallback = null,
   autoRefresh = true,
   loginOptions,
+  tokenExpirationBuffer,
 }: RequireAuthProps) {
   const { isAuthenticated, isLoading, tokens, actions } = useAuth();
   const refreshAttempted = useRef(false);
 
-  const isExpired = tokens.expiresAt !== null && tokens.expiresAt <= Date.now();
+  const isExpired = isExpiredAt(tokens.expiresAt, tokenExpirationBuffer);
   const needsAuth = !isAuthenticated || isExpired;
 
   useEffect(() => {

--- a/packages/react/src/tests/auth-required.test.tsx
+++ b/packages/react/src/tests/auth-required.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import { RequireAuth } from "../auth-required.js";
 import type { AuthContextValue } from "../types.js";
@@ -46,7 +47,7 @@ afterEach(() => {
 describe("RequireAuth", () => {
   it("renders children when authenticated", () => {
     mockUseAuth.mockReturnValue(
-      makeAuth({ isAuthenticated: true, tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 } }),
+      makeAuth({ isAuthenticated: true, tokens: { access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 } }),
     );
 
     render(
@@ -114,7 +115,7 @@ describe("RequireAuth", () => {
     mockUseAuth.mockReturnValue(
       makeAuth({
         isAuthenticated: true,
-        tokens: { access: "expired", id: null, refresh: "valid-refresh", expiresAt: Date.now() - 60_000 },
+        tokens: { access: "expired", id: null, refresh: "valid-refresh", expiresAt: nowSeconds() - 60 },
         actions,
       }),
     );
@@ -134,7 +135,7 @@ describe("RequireAuth", () => {
     mockUseAuth.mockReturnValue(
       makeAuth({
         isAuthenticated: true,
-        tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 },
+        tokens: { access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 },
       }),
     );
 

--- a/packages/react/src/tests/context.test.tsx
+++ b/packages/react/src/tests/context.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { type ReactNode } from "react";
 import { AuthProvider, useAuth } from "../context.js";
@@ -35,8 +36,8 @@ const TOKEN_RESPONSE = {
     sub: "user-1",
     iss: "https://auth.example.com",
     aud: "my-app",
-    exp: Math.floor(Date.now() / 1000) + 3600,
-    iat: Math.floor(Date.now() / 1000),
+    exp: nowSeconds() + 3600,
+    iat: nowSeconds(),
     nonce: "test-nonce",
   }),
   refresh_token: "rt_123",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-solid",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Simple OIDC authentication for SolidJS. Signals, context, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/solid/src/auth-required.tsx
+++ b/packages/solid/src/auth-required.tsx
@@ -1,6 +1,7 @@
 import { Show, createEffect, type JSX, type ParentComponent } from "solid-js";
 import { useAuth } from "./context.js";
 import type { LoginOptions } from "oidc-js";
+import { isExpiredAt } from "oidc-js-core";
 
 /**
  * Props for the {@link RequireAuth} component.
@@ -12,6 +13,8 @@ interface RequireAuthProps {
   autoRefresh?: boolean;
   /** Additional options passed to the login redirect. */
   loginOptions?: LoginOptions;
+  /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
+  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -32,7 +35,7 @@ export const RequireAuth: ParentComponent<RequireAuthProps> = (props) => {
   let refreshAttempted = false;
 
   createEffect(() => {
-    const isExpired = auth.tokens.expiresAt !== null && auth.tokens.expiresAt <= Date.now();
+    const isExpired = isExpiredAt(auth.tokens.expiresAt, props.tokenExpirationBuffer);
     const needsAuth = !auth.isAuthenticated || isExpired;
 
     if (!needsAuth) {
@@ -54,7 +57,7 @@ export const RequireAuth: ParentComponent<RequireAuthProps> = (props) => {
 
   return (
     <Show
-      when={!auth.isLoading && auth.isAuthenticated && !(auth.tokens.expiresAt !== null && auth.tokens.expiresAt <= Date.now())}
+      when={!auth.isLoading && auth.isAuthenticated && !isExpiredAt(auth.tokens.expiresAt, props.tokenExpirationBuffer)}
       fallback={props.fallback}
     >
       {props.children}

--- a/packages/solid/src/tests/auth-required.test.tsx
+++ b/packages/solid/src/tests/auth-required.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import { render, screen, cleanup, waitFor } from "@solidjs/testing-library";
 import { RequireAuth } from "../auth-required.js";
 import type { AuthContextValue } from "../types.js";
@@ -53,7 +54,7 @@ describe("RequireAuth", () => {
   it("renders children when authenticated", () => {
     resetAuth({
       isAuthenticated: true,
-      tokens: { access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 },
+      tokens: { access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 },
     });
 
     render(() => (
@@ -131,7 +132,7 @@ describe("RequireAuth", () => {
     };
     resetAuth({
       isAuthenticated: true,
-      tokens: { access: "expired", id: null, refresh: "valid-refresh", expiresAt: Date.now() - 60_000 },
+      tokens: { access: "expired", id: null, refresh: "valid-refresh", expiresAt: nowSeconds() - 60 },
       actions,
     });
 

--- a/packages/solid/src/tests/context.test.tsx
+++ b/packages/solid/src/tests/context.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import { render, screen, waitFor, cleanup } from "@solidjs/testing-library";
 import { AuthProvider, useAuth } from "../context.js";
 import type { OidcConfig } from "oidc-js-core";
@@ -34,8 +35,8 @@ const TOKEN_RESPONSE = {
     sub: "user-1",
     iss: "https://auth.example.com",
     aud: "my-app",
-    exp: Math.floor(Date.now() / 1000) + 3600,
-    iat: Math.floor(Date.now() / 1000),
+    exp: nowSeconds() + 3600,
+    iat: nowSeconds(),
     nonce: "test-nonce",
   }),
   refresh_token: "rt_123",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-svelte",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Simple OIDC authentication for Svelte 5. Context, runes, and auth guards with zero dependencies.",
   "type": "module",
   "svelte": "./dist/index.js",

--- a/packages/svelte/src/RequireAuth.svelte
+++ b/packages/svelte/src/RequireAuth.svelte
@@ -21,6 +21,7 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
   import type { LoginOptions } from "oidc-js";
+  import { isExpiredAt } from "oidc-js-core";
   import { getAuthContext } from "./context.svelte.js";
 
   interface Props {
@@ -32,15 +33,17 @@
     autoRefresh?: boolean;
     /** Options to pass to the login redirect if authentication is required. */
     loginOptions?: LoginOptions;
+    /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
+    tokenExpirationBuffer?: number;
   }
 
-  let { children, fallback, autoRefresh = true, loginOptions }: Props = $props();
+  let { children, fallback, autoRefresh = true, loginOptions, tokenExpirationBuffer }: Props = $props();
 
   const auth = getAuthContext();
   let refreshAttempted = false;
 
   $effect(() => {
-    const isExpired = auth.tokens.expiresAt !== null && auth.tokens.expiresAt <= Date.now();
+    const isExpired = isExpiredAt(auth.tokens.expiresAt, tokenExpirationBuffer);
     const needsAuth = !auth.isAuthenticated || isExpired;
 
     if (!needsAuth) {
@@ -59,7 +62,7 @@
   });
 </script>
 
-{#if auth.isLoading || !auth.isAuthenticated || (auth.tokens.expiresAt !== null && auth.tokens.expiresAt <= Date.now())}
+{#if auth.isLoading || !auth.isAuthenticated || isExpiredAt(auth.tokens.expiresAt, tokenExpirationBuffer)}
   {#if fallback}
     {@render fallback()}
   {/if}

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-vue",
-  "version": "1.0.4",
+  "version": "1.0.6",
   "description": "Simple OIDC authentication for Vue. Plugin, composables, and navigation guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/vue/src/auth-required.ts
+++ b/packages/vue/src/auth-required.ts
@@ -1,6 +1,7 @@
 import { defineComponent, ref, watch, type PropType, type VNode } from "vue";
 import { useAuth } from "./composable.js";
 import type { LoginOptions } from "oidc-js";
+import { isExpiredAt } from "oidc-js-core";
 
 /**
  * Renderless component that guards its slot content behind authentication.
@@ -36,6 +37,11 @@ export const RequireAuth = defineComponent({
       type: Object as PropType<LoginOptions>,
       default: undefined,
     },
+    /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
+    tokenExpirationBuffer: {
+      type: Number,
+      default: undefined,
+    },
   },
   setup(props, { slots }) {
     const { isAuthenticated, isLoading, tokens, actions } = useAuth();
@@ -44,9 +50,7 @@ export const RequireAuth = defineComponent({
     watch(
       [isAuthenticated, isLoading, tokens],
       () => {
-        const isExpired =
-          tokens.value.expiresAt !== null &&
-          tokens.value.expiresAt <= Date.now();
+        const isExpired = isExpiredAt(tokens.value.expiresAt, props.tokenExpirationBuffer);
         const needsAuth = !isAuthenticated.value || isExpired;
 
         if (!needsAuth) {
@@ -68,9 +72,7 @@ export const RequireAuth = defineComponent({
     );
 
     return (): VNode | VNode[] | null => {
-      const isExpired =
-        tokens.value.expiresAt !== null &&
-        tokens.value.expiresAt <= Date.now();
+      const isExpired = isExpiredAt(tokens.value.expiresAt, props.tokenExpirationBuffer);
       const needsAuth = !isAuthenticated.value || isExpired;
 
       if (isLoading.value || needsAuth) {

--- a/packages/vue/src/guard.ts
+++ b/packages/vue/src/guard.ts
@@ -1,6 +1,7 @@
 import { inject } from "vue";
 import { AUTH_CONTEXT_KEY } from "./plugin.js";
 import type { LoginOptions } from "oidc-js";
+import { isExpiredAt } from "oidc-js-core";
 
 /**
  * Options for the {@link createAuthGuard} navigation guard.
@@ -8,6 +9,8 @@ import type { LoginOptions } from "oidc-js";
 export interface AuthGuardOptions {
   /** Options to pass to the login method when redirecting unauthenticated users. */
   loginOptions?: LoginOptions;
+  /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
+  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -59,9 +62,7 @@ export function createAuthGuard(
       });
     }
 
-    const isExpired =
-      context.tokens.value.expiresAt !== null &&
-      context.tokens.value.expiresAt <= Date.now();
+    const isExpired = isExpiredAt(context.tokens.value.expiresAt, options?.tokenExpirationBuffer);
 
     if (context.isAuthenticated.value && !isExpired) {
       next();

--- a/packages/vue/src/tests/auth-required.test.ts
+++ b/packages/vue/src/tests/auth-required.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import { defineComponent, ref, provide, h } from "vue";
 import { mount } from "@vue/test-utils";
 import { RequireAuth } from "../auth-required.js";
@@ -46,7 +47,7 @@ describe("RequireAuth", () => {
   it("renders default slot when authenticated", () => {
     const wrapper = mount(makeWrapper({
       isAuthenticated: ref(true),
-      tokens: ref({ access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 }),
+      tokens: ref({ access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 }),
     }), {
       slots: {
         default: () => h(RequireAuth, null, {
@@ -123,7 +124,7 @@ describe("RequireAuth", () => {
 
     mount(makeWrapper({
       isAuthenticated: ref(true),
-      tokens: ref({ access: "expired", id: null, refresh: "valid-refresh", expiresAt: Date.now() - 60_000 }),
+      tokens: ref({ access: "expired", id: null, refresh: "valid-refresh", expiresAt: nowSeconds() - 60 }),
       actions,
     }), {
       slots: {

--- a/packages/vue/src/tests/guard.test.ts
+++ b/packages/vue/src/tests/guard.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { nowSeconds } from "oidc-js-core";
 import { ref } from "vue";
 import { createAuthGuard } from "../guard.js";
 
@@ -58,7 +59,7 @@ describe("createAuthGuard", () => {
   it("allows navigation when authenticated", async () => {
     const context = makeContext({
       isAuthenticated: ref(true),
-      tokens: ref({ access: "token", id: null, refresh: null, expiresAt: Date.now() + 3600_000 }),
+      tokens: ref({ access: "token", id: null, refresh: null, expiresAt: nowSeconds() + 3600 }),
     });
     vi.mocked(inject).mockReturnValue(context);
 
@@ -94,7 +95,7 @@ describe("createAuthGuard", () => {
     const actions = makeActions();
     const context = makeContext({
       isAuthenticated: ref(true),
-      tokens: ref({ access: "expired", id: null, refresh: "rt", expiresAt: Date.now() - 60_000 }),
+      tokens: ref({ access: "expired", id: null, refresh: "rt", expiresAt: nowSeconds() - 60 }),
       actions,
     });
     vi.mocked(inject).mockReturnValue(context);
@@ -116,7 +117,7 @@ describe("createAuthGuard", () => {
     });
     const context = makeContext({
       isAuthenticated: ref(true),
-      tokens: ref({ access: "expired", id: null, refresh: "rt", expiresAt: Date.now() - 60_000 }),
+      tokens: ref({ access: "expired", id: null, refresh: "rt", expiresAt: nowSeconds() - 60 }),
       actions,
     });
     vi.mocked(inject).mockReturnValue(context);

--- a/tests/e2e/specs/login.spec.ts
+++ b/tests/e2e/specs/login.spec.ts
@@ -419,7 +419,7 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
     await page.evaluate((exp) => {
       const realDateNow = Date.now;
       const originalFetch = window.fetch;
-      Date.now = () => exp + 1;
+      Date.now = () => (exp + 1) * 1000;
       window.fetch = function (...args: Parameters<typeof fetch>) {
         return originalFetch.apply(window, args).then((response) => {
           if (new URL(response.url).pathname === "/oauth2/token") {
@@ -462,7 +462,7 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
     await page.evaluate((exp) => {
       const realDateNow = Date.now;
       const originalFetch = window.fetch;
-      Date.now = () => exp + 1;
+      Date.now = () => (exp + 1) * 1000;
       window.fetch = function (...args: Parameters<typeof fetch>) {
         return originalFetch.apply(window, args).then((response) => {
           if (new URL(response.url).pathname === "/oauth2/token") {

--- a/tests/e2e/specs/login.spec.ts
+++ b/tests/e2e/specs/login.spec.ts
@@ -23,6 +23,8 @@ const OIDC_PATHS = [
   "/oauth2/logout",
 ];
 
+// Records OIDC-related XHR/fetch requests and document navigations to the IdP,
+// allowing tests to assert the exact protocol sequence for each flow.
 function trackTraffic(page: Page) {
   const log: TrafficEntry[] = [];
   const navs: string[] = [];
@@ -54,6 +56,7 @@ function trackTraffic(page: Page) {
   };
 }
 
+// Performs a full login: navigates to app, clicks login, fills IdP form, waits for redirect back.
 async function login(page: Page) {
   await page.goto("/");
   await page.getByTestId("login-button").click();
@@ -65,6 +68,29 @@ async function login(page: Page) {
   await expect(page.getByTestId("authenticated")).toBeVisible({ timeout: TIMEOUT });
 }
 
+// Advances Date.now past token expiry to simulate an expired token in the browser.
+// Intercepts fetch to restore real time after the token refresh request completes,
+// so the newly-issued token doesn't also appear expired.
+// offsetSeconds controls where to place the clock relative to expiresAt (default: +1 = just past expiry).
+async function simulateTokenExpiry(page: Page, expiresAt: number, offsetSeconds = 1) {
+  await page.evaluate(({ exp, offset }) => {
+    const realDateNow = Date.now;
+    const originalFetch = window.fetch;
+    // expiresAt is in seconds (OIDC), Date.now() must return ms (browser API)
+    Date.now = () => (exp + offset) * 1000;
+    window.fetch = function (...args: Parameters<typeof fetch>) {
+      return originalFetch.apply(window, args).then((response) => {
+        if (new URL(response.url).pathname === "/oauth2/token") {
+          Date.now = realDateNow;
+          window.fetch = originalFetch;
+        }
+        return response;
+      });
+    } as typeof fetch;
+  }, { exp: expiresAt, offset: offsetSeconds });
+}
+
+// Calls the IdP's revocation endpoint server-side to invalidate a token mid-test.
 async function revokeToken(token: string, hint?: string) {
   const body: Record<string, string> = { token, client_id: "e2e-test-app" };
   if (hint) body.token_type_hint = hint;
@@ -104,6 +130,7 @@ const LOGIN_SEQUENCE = [
 ];
 
 test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
+  // Verifies the app's initial unauthenticated state and that only discovery is fetched.
   test("shows login button when not authenticated", async ({ page }) => {
     const traffic = trackTraffic(page);
     await page.goto("/");
@@ -119,6 +146,7 @@ test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
     ]);
   });
 
+  // Full OIDC authorization code flow: login via IdP, verify all three tokens are present.
   test("completes full login flow with tokens", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -131,6 +159,7 @@ test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
     expect(traffic.sequence()).toEqual(LOGIN_SEQUENCE);
   });
 
+  // Verifies the decoded ID token contains all required OIDC claims (sub, iss, aud, exp, iat).
   test("user.claims has required OIDC fields", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -145,6 +174,7 @@ test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
     expect(traffic.sequence()).toEqual(LOGIN_SEQUENCE);
   });
 
+  // When fetchProfile=true (default), the userinfo endpoint is called and profile data is available.
   test("user.profile is populated when fetchProfile is true", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -156,6 +186,7 @@ test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
     expect(traffic.sequence()).toEqual(LOGIN_SEQUENCE);
   });
 
+  // When fetchProfile=false (set via localStorage toggle), userinfo is skipped and profile is null.
   test("user.profile is null when fetchProfile is false", async ({ page }) => {
     const traffic = trackTraffic(page);
     await page.goto("/", { waitUntil: "networkidle" });
@@ -188,6 +219,7 @@ test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
     ]);
   });
 
+  // Logout navigates to the IdP's end_session_endpoint and clears local auth state.
   test("logout clears state", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -213,6 +245,7 @@ test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
     ]);
   });
 
+  // Clicking the refresh button exchanges the refresh_token for a new access_token.
   test("manual token refresh", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -232,9 +265,23 @@ test.describe(`[${FRAMEWORK}] OIDC Login Flow`, () => {
       GET_USERINFO,
     ]);
   });
+
+  // After refresh, the IdP rotates the refresh_token. The library must store the new one,
+  // otherwise subsequent refreshes would fail with an invalid/revoked token.
+  test("refresh token is rotated after refresh", async ({ page }) => {
+    await login(page);
+    const oldRefresh = await page.getByTestId("refresh-token-value").textContent();
+    await page.getByTestId("refresh-button").click();
+    await expect(page.getByTestId("refresh-token-value")).not.toHaveText(oldRefresh!, { timeout: TIMEOUT });
+
+    const newRefresh = await page.getByTestId("refresh-token-value").textContent();
+    expect(newRefresh).toBeTruthy();
+    expect(newRefresh).not.toBe(oldRefresh);
+  });
 });
 
 test.describe(`[${FRAMEWORK}] Session Lifecycle`, () => {
+  // After the callback, ?code= and ?state= params are stripped via history.replaceState.
   test("cleans callback URL params after login", async ({ page }) => {
     await login(page);
     const url = new URL(page.url());
@@ -242,6 +289,7 @@ test.describe(`[${FRAMEWORK}] Session Lifecycle`, () => {
     expect(url.searchParams.has("state")).toBe(false);
   });
 
+  // Tokens are kept in-memory only, so a hard reload loses the session.
   test("loses session on page reload (in-memory only)", async ({ page }) => {
     await login(page);
     await expect(page.getByTestId("authenticated")).toBeVisible();
@@ -251,6 +299,7 @@ test.describe(`[${FRAMEWORK}] Session Lifecycle`, () => {
     await expect(page.getByTestId("unauthenticated")).toBeVisible({ timeout: TIMEOUT });
   });
 
+  // Ensures no stale auth state leaks between login/logout cycles.
   test("completes multiple login/logout cycles without stale state", async ({ page }) => {
     await login(page);
     await expect(page.getByTestId("authenticated")).toBeVisible();
@@ -268,6 +317,7 @@ test.describe(`[${FRAMEWORK}] Session Lifecycle`, () => {
     await expect(page.getByTestId("access-token")).toHaveText("present");
   });
 
+  // After an OAuth error callback, the user can start a fresh login successfully.
   test("recovers from error state with fresh login", async ({ page }) => {
     await page.goto("/?error=access_denied&error_description=User+denied+consent");
     await expect(page.getByTestId("auth-error")).toBeVisible();
@@ -280,6 +330,7 @@ test.describe(`[${FRAMEWORK}] Session Lifecycle`, () => {
 });
 
 test.describe(`[${FRAMEWORK}] Security`, () => {
+  // Verifies tokens are never persisted to web storage (XSS mitigation).
   test("tokens are not stored in localStorage or sessionStorage", async ({ page }) => {
     await login(page);
 
@@ -299,6 +350,7 @@ test.describe(`[${FRAMEWORK}] Security`, () => {
     expect(storedTokens).not.toContain("id_token");
   });
 
+  // Browser back-button after logout must not expose stale authenticated content.
   test("back button after logout does not show authenticated content", async ({ page }) => {
     await login(page);
     await expect(page.getByTestId("authenticated")).toBeVisible();
@@ -313,6 +365,7 @@ test.describe(`[${FRAMEWORK}] Security`, () => {
 });
 
 test.describe(`[${FRAMEWORK}] Error Handling`, () => {
+  // OAuth error params in the callback URL (e.g. access_denied) surface as a visible error.
   test("shows error when IdP returns error in callback", async ({ page }) => {
     const traffic = trackTraffic(page);
     await page.goto("/?error=access_denied&error_description=User+denied+consent");
@@ -328,6 +381,7 @@ test.describe(`[${FRAMEWORK}] Error Handling`, () => {
     ]);
   });
 
+  // State mismatch between stored and callback value is caught (CSRF protection).
   test("shows error when callback state does not match (CSRF protection)", async ({ page }) => {
     const traffic = trackTraffic(page);
     await page.goto("/");
@@ -358,6 +412,7 @@ test.describe(`[${FRAMEWORK}] Error Handling`, () => {
 });
 
 test.describe(`[${FRAMEWORK}] Deep Linking`, () => {
+  // Navigating to a protected route while unauthenticated redirects to IdP, then back to the original path.
   test("login from protected page returns to that page", async ({ page }) => {
     const traffic = trackTraffic(page);
     await page.goto("/protected-a", { waitUntil: "networkidle" });
@@ -377,6 +432,7 @@ test.describe(`[${FRAMEWORK}] Deep Linking`, () => {
 });
 
 test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
+  // RequireAuth renders children when user is authenticated with a valid token.
   test("shows protected content when authenticated", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -388,6 +444,7 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
     expect(traffic.sequence()).toEqual(LOGIN_SEQUENCE);
   });
 
+  // Client-side navigation between protected routes does not trigger new auth requests.
   test("navigates between protected pages without re-authentication", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -408,6 +465,9 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
     expect(traffic.sequence()).toEqual(LOGIN_SEQUENCE);
   });
 
+  // Simulates token expiration by advancing Date.now past expiresAt, then navigating
+  // to a protected page. RequireAuth should detect the expired token and auto-refresh.
+  // After the token endpoint responds, Date.now and fetch are restored so the new token works normally.
   test("auto-refreshes expired token when navigating to protected page", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -416,20 +476,7 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
     await page.getByTestId("link-protected-a").click();
     await expect(page.getByTestId("protected-a")).toBeVisible();
 
-    await page.evaluate((exp) => {
-      const realDateNow = Date.now;
-      const originalFetch = window.fetch;
-      Date.now = () => (exp + 1) * 1000;
-      window.fetch = function (...args: Parameters<typeof fetch>) {
-        return originalFetch.apply(window, args).then((response) => {
-          if (new URL(response.url).pathname === "/oauth2/token") {
-            Date.now = realDateNow;
-            window.fetch = originalFetch;
-          }
-          return response;
-        });
-      } as typeof fetch;
-    }, expiresAt);
+    await simulateTokenExpiry(page, expiresAt);
 
     await page.getByTestId("link-protected-b").click();
     await expect(page.getByTestId("protected-b")).toBeVisible({ timeout: TIMEOUT });
@@ -447,6 +494,8 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
     ]);
   });
 
+  // Same time-travel technique as above, but with the refresh_token revoked server-side.
+  // The refresh attempt fails, so the user is redirected to login.
   test("redirects to login when refresh token is revoked", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -459,20 +508,7 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
 
     await revokeToken(refreshToken!, "refresh_token");
 
-    await page.evaluate((exp) => {
-      const realDateNow = Date.now;
-      const originalFetch = window.fetch;
-      Date.now = () => (exp + 1) * 1000;
-      window.fetch = function (...args: Parameters<typeof fetch>) {
-        return originalFetch.apply(window, args).then((response) => {
-          if (new URL(response.url).pathname === "/oauth2/token") {
-            Date.now = realDateNow;
-            window.fetch = originalFetch;
-          }
-          return response;
-        });
-      } as typeof fetch;
-    }, expiresAt);
+    await simulateTokenExpiry(page, expiresAt);
 
     await page.getByTestId("link-protected-b").click();
     await expect(page.locator('input[name="username"]')).toBeVisible({ timeout: TIMEOUT });
@@ -491,9 +527,58 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
       NAV_AUTHORIZE,
     ]);
   });
+
+  // RequireAuth unmounts when leaving a protected page. This test verifies that when it
+  // re-mounts (fresh) with an expired token, it correctly triggers a refresh on initial render.
+  // Flow: protected-a → home (unmount) → expire → protected-a (fresh mount with expired token).
+  test("auto-refreshes expired token on fresh mount after leaving protected page", async ({ page }) => {
+    const traffic = trackTraffic(page);
+    await login(page);
+    const expiresAt = Number(await page.getByTestId("expires-at").textContent());
+
+    await page.getByTestId("link-protected-a").click();
+    await expect(page.getByTestId("protected-a")).toBeVisible();
+
+    // Navigate to public page (RequireAuth unmounts)
+    await page.getByTestId("link-home").click();
+    await expect(page.getByTestId("authenticated")).toBeVisible();
+
+    await simulateTokenExpiry(page, expiresAt);
+
+    // Navigate back to protected page (RequireAuth mounts fresh, detects expired token)
+    await page.getByTestId("link-protected-a").click();
+    await expect(page.getByTestId("protected-a")).toBeVisible({ timeout: TIMEOUT });
+
+    const postLoginRequests = traffic.requests().slice(LOGIN_REQUESTS.length);
+    expect(postLoginRequests).toContain(POST_TOKEN);
+  });
+
+  // Verifies the 30-second expiration buffer: the token hasn't technically expired yet,
+  // but we're within the buffer window, so the library should proactively refresh.
+  // Time is set to (exp - 10)s — 10 seconds before actual expiry, 20 seconds into the buffer.
+  test("proactively refreshes token within the expiration buffer window", async ({ page }) => {
+    const traffic = trackTraffic(page);
+    await login(page);
+    const expiresAt = Number(await page.getByTestId("expires-at").textContent());
+
+    await page.getByTestId("link-protected-a").click();
+    await expect(page.getByTestId("protected-a")).toBeVisible();
+
+    // Set time to 10s before actual expiry — within the 30s buffer.
+    // isExpiredAt check: (exp - 10) >= exp - 30 → true, triggers refresh.
+    await simulateTokenExpiry(page, expiresAt, -10);
+
+    await page.getByTestId("link-protected-b").click();
+    await expect(page.getByTestId("protected-b")).toBeVisible({ timeout: TIMEOUT });
+
+    const postLoginRequests = traffic.requests().slice(LOGIN_REQUESTS.length);
+    expect(postLoginRequests).toContain(POST_TOKEN);
+  });
 });
 
 test.describe(`[${FRAMEWORK}] Nonce Validation`, () => {
+  // Tampers with the stored nonce before callback. The library should detect the mismatch
+  // and surface an error instead of accepting the tokens (prevents token injection/replay).
   test("rejects token when nonce is tampered (replay protection)", async ({ page }) => {
     const traffic = trackTraffic(page);
 
@@ -527,6 +612,8 @@ test.describe(`[${FRAMEWORK}] Nonce Validation`, () => {
 });
 
 test.describe(`[${FRAMEWORK}] PKCE Security`, () => {
+  // Performs two login flows and asserts that state, nonce, and code_challenge differ each time.
+  // This ensures PKCE values are freshly generated (no reuse = no replay attacks).
   test("generates unique state, nonce, and code_challenge for each login", async ({ page }) => {
     const authParams: URLSearchParams[] = [];
     page.on("request", (req) => {
@@ -559,6 +646,8 @@ test.describe(`[${FRAMEWORK}] PKCE Security`, () => {
 });
 
 test.describe(`[${FRAMEWORK}] Refresh Deduplication`, () => {
+  // Dispatches two refresh clicks synchronously and asserts only one POST /token is made.
+  // Verifies the library deduplicates concurrent refresh calls.
   test("concurrent refresh calls produce only one token request", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -580,6 +669,8 @@ test.describe(`[${FRAMEWORK}] Refresh Deduplication`, () => {
 });
 
 test.describe(`[${FRAMEWORK}] Token Revocation`, () => {
+  // Revokes the access token server-side, then fetches profile. The app should handle
+  // the 401 gracefully without crashing or logging the user out.
   test("handles revoked access token gracefully on userinfo fetch", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -596,6 +687,7 @@ test.describe(`[${FRAMEWORK}] Token Revocation`, () => {
     expect(postLoginRequests).toContain(GET_USERINFO);
   });
 
+  // Manual refresh gets a new access token, then userinfo works with the new token.
   test("manual refresh obtains new tokens after normal expiry", async ({ page }) => {
     const traffic = trackTraffic(page);
     await login(page);
@@ -618,6 +710,8 @@ test.describe(`[${FRAMEWORK}] Token Revocation`, () => {
 });
 
 test.describe(`[${FRAMEWORK}] Concurrent Tabs`, () => {
+  // Opens two tabs, starts login in both, completes them sequentially.
+  // Each tab's PKCE state is independent so both sessions authenticate successfully.
   test("concurrent logins in separate tabs do not interfere", async ({ page, context }) => {
     const page2 = await context.newPage();
 


### PR DESCRIPTION
## Summary
- Add `isExpiredAt(expiresAt, bufferSeconds = 30)` and `nowSeconds()` to core, replacing all inline `expiresAt <= Date.now()` checks across adapters
- Unify on **seconds** throughout (matching OIDC/JWT conventions) — `AuthTokens.expiresAt` is now seconds, not milliseconds
- Each adapter's `RequireAuth` / auth guard accepts an optional `tokenExpirationBuffer` (seconds), defaulting to 30s
- Remove dead `isTokenExpired(tokenSet)` function from core
- Add `createAuthGuard(options?)` factory for Angular (backwards-compatible, `authGuard` still exported as default)

## Breaking changes
- `AuthTokens.expiresAt` changed from milliseconds to seconds (Unix epoch)
- `isTokenExpired` removed from core exports (use `isExpiredAt` instead)
- `timeUntilExpiry` signature changed: now takes `number | null` (seconds) instead of `TokenSet`

## Test plan
- [x] Core unit tests pass (98 tests)
- [x] All adapter tests pass (Angular, Vue, Lit, Kasper, React, Preact, Solid)
- [x] Full monorepo build succeeds
- [x] Type-checking passes across all packages

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)