### PR TITLE
docs: fix stale references in docs-web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Purely functional — every function takes data in and returns data out. No `fet
 - **`revocation.ts`** — `buildRevocationRequest` (returns null if no endpoint)
 - **`logout.ts`** — `buildLogoutUrl` (returns null if no end_session_endpoint)
 - **`jwt.ts`** — `decodeJwtPayload`, `parseIdTokenClaims` (decode only, no signature verification)
-- **`token-utils.ts`** — `computeExpiresAt`, `isTokenExpired`, `timeUntilExpiry`
+- **`token-utils.ts`** — `computeExpiresAt`, `isExpiredAt`, `timeUntilExpiry`, `nowSeconds`, `DEFAULT_TOKEN_EXPIRATION_BUFFER`
 
 ### Config model
 

--- a/docs-web/src/content/docs/core/overview.mdx
+++ b/docs-web/src/content/docs/core/overview.mdx
@@ -46,7 +46,7 @@ const discovery = parseDiscoveryResponse(json, expectedIssuer);
 | Revocation | `buildRevocationRequest` |
 | Logout | `buildLogoutUrl` |
 | JWT | `decodeJwtPayload`, `parseIdTokenClaims` |
-| Token Utils | `computeExpiresAt`, `isTokenExpired`, `timeUntilExpiry` |
+| Token Utils | `computeExpiresAt`, `isExpiredAt`, `timeUntilExpiry`, `nowSeconds` |
 | Crypto | `generatePkce`, `generateState`, `generateNonce`, `computeCodeChallenge` |
 
 ## Error handling

--- a/docs-web/src/content/docs/guides/protected-routes.mdx
+++ b/docs-web/src/content/docs/guides/protected-routes.mdx
@@ -24,11 +24,25 @@ function Dashboard() {
 
 If the user is not authenticated, `RequireAuth` automatically redirects to the IdP login page.
 
+<Aside type="note">
+All framework adapters provide an equivalent component or guard: `RequireAuth` (React, Preact, Solid, Svelte, Lit, Kasper), `AuthRequired` (Vue), and `authGuard` (Angular). The examples below use React, but the same patterns apply across frameworks.
+</Aside>
+
 ## With React Router
 
+Use a layout route with a single `RequireAuth` to protect all nested routes at once:
+
 ```tsx
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Outlet } from "react-router";
 import { AuthProvider, RequireAuth } from "oidc-js-react";
+
+function ProtectedLayout() {
+  return (
+    <RequireAuth>
+      <Outlet />
+    </RequireAuth>
+  );
+}
 
 function App() {
   return (
@@ -36,27 +50,31 @@ function App() {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Home />} />
-          <Route
-            path="/dashboard"
-            element={
-              <RequireAuth>
-                <Dashboard />
-              </RequireAuth>
-            }
-          />
-          <Route
-            path="/settings"
-            element={
-              <RequireAuth>
-                <Settings />
-              </RequireAuth>
-            }
-          />
+          <Route element={<ProtectedLayout />}>
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/settings" element={<Settings />} />
+          </Route>
         </Routes>
       </BrowserRouter>
     </AuthProvider>
   );
 }
+```
+
+You can also wrap individual routes if only specific pages need protection:
+
+```tsx
+<Routes>
+  <Route path="/" element={<Home />} />
+  <Route
+    path="/dashboard"
+    element={
+      <RequireAuth>
+        <Dashboard />
+      </RequireAuth>
+    }
+  />
+</Routes>
 ```
 
 ## Loading fallback

--- a/docs-web/src/content/docs/guides/token-refresh.mdx
+++ b/docs-web/src/content/docs/guides/token-refresh.mdx
@@ -29,13 +29,21 @@ sequenceDiagram
 
 `RequireAuth` handles refresh automatically. When a user navigates to a protected route with an expired token:
 
-1. Checks `tokens.expiresAt` against `Date.now()`
+1. Checks `tokens.expiresAt` using `isExpiredAt()` from core (with an optional buffer)
 2. If expired, calls `actions.refresh()`
 3. If refresh succeeds, renders the children with new tokens
 4. If refresh fails, redirects to login
 
 ```tsx
 <RequireAuth>
+  <Dashboard />
+</RequireAuth>
+```
+
+You can set a `tokenExpirationBuffer` (in seconds) to refresh the token early, accounting for clock skew and network latency. The default buffer is 30 seconds.
+
+```tsx
+<RequireAuth tokenExpirationBuffer={60}>
   <Dashboard />
 </RequireAuth>
 ```
@@ -69,15 +77,29 @@ The `tokens` object from `useAuth` includes expiry information:
 ```tsx
 const { tokens } = useAuth();
 
-// Millisecond timestamp when the access token expires
+// Unix timestamp in seconds when the access token expires
 console.log(tokens.expiresAt);
+```
 
-// Check if expired
-const isExpired = tokens.expiresAt !== null && tokens.expiresAt <= Date.now();
+Use the helper functions from `oidc-js-core` to work with token expiry:
+
+```tsx
+import { isExpiredAt, timeUntilExpiry } from "oidc-js-core";
+
+const { tokens } = useAuth();
+
+// Check if expired (includes a default 30-second buffer)
+const expired = isExpiredAt(tokens.expiresAt);
+
+// Check with a custom buffer (in seconds)
+const expiringSoon = isExpiredAt(tokens.expiresAt, 120);
+
+// Get seconds remaining until expiry
+const secondsLeft = timeUntilExpiry(tokens.expiresAt);
 ```
 
 <Aside type="note">
-The `expiresAt` value is extracted from the `exp` claim in the JWT access token and converted to milliseconds. If the access token is not a JWT or doesn't contain an `exp` claim, `expiresAt` will be `null`.
+The `expiresAt` value is extracted from the `exp` claim in the JWT access token as a Unix timestamp in seconds. If the access token is not a JWT or doesn't contain an `exp` claim, `expiresAt` will be `null`.
 </Aside>
 
 ## Requesting a refresh token

--- a/docs-web/src/content/docs/react/auth-provider.mdx
+++ b/docs-web/src/content/docs/react/auth-provider.mdx
@@ -57,7 +57,7 @@ interface OidcConfig {
 By default, `AuthProvider` restores the pre-login URL using `window.history.replaceState`. If you're using a client-side router, you may want to handle navigation yourself:
 
 ```tsx
-import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router";
 
 function App() {
   const navigate = useNavigate();

--- a/docs-web/src/content/docs/react/require-auth.mdx
+++ b/docs-web/src/content/docs/react/require-auth.mdx
@@ -67,7 +67,7 @@ When a user navigates to a protected route:
 ## With React Router
 
 ```tsx
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route } from "react-router";
 import { RequireAuth } from "oidc-js-react";
 
 <Routes>

--- a/docs-web/src/content/docs/react/use-auth.mdx
+++ b/docs-web/src/content/docs/react/use-auth.mdx
@@ -58,7 +58,7 @@ interface AuthTokens {
   access: string | null;     // Access token
   id: string | null;         // ID token
   refresh: string | null;    // Refresh token
-  expiresAt: number | null;  // Expiry timestamp in milliseconds
+  expiresAt: number | null;  // Expiry timestamp in seconds (Unix)
 }
 ```
 


### PR DESCRIPTION
## Summary

- **`react-router-dom` → `react-router`** in all React examples (auth-provider, require-auth, protected-routes)
- **`isTokenExpired` → `isExpiredAt`** in core overview function table and CLAUDE.md
- **`expiresAt` "milliseconds" → "seconds (Unix)"** in use-auth tokens interface comment
- **Token refresh guide**: replaced `Date.now()` comparison with `isExpiredAt()`/`timeUntilExpiry()` helpers, documented `tokenExpirationBuffer` prop
- **Protected routes guide**: added framework-agnostic note, added layout route pattern with `<Outlet />`, kept per-route wrapping as alternative

## Test plan

- [ ] Verify docs-web builds without errors
- [ ] Review code examples for correctness against current API
- [ ] Check that all import paths reference correct packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)