### PR TITLE
feat: support expiryBuffer as global config option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Purely functional — every function takes data in and returns data out. No `fet
 - **`revocation.ts`** — `buildRevocationRequest` (returns null if no endpoint)
 - **`logout.ts`** — `buildLogoutUrl` (returns null if no end_session_endpoint)
 - **`jwt.ts`** — `decodeJwtPayload`, `parseIdTokenClaims` (decode only, no signature verification)
-- **`token-utils.ts`** — `computeExpiresAt`, `isExpiredAt`, `timeUntilExpiry`, `nowSeconds`, `DEFAULT_TOKEN_EXPIRATION_BUFFER`
+- **`token-utils.ts`** — `computeExpiresAt`, `isExpiredAt`, `timeUntilExpiry`, `nowSeconds`, `DEFAULT_EXPIRY_BUFFER`
 
 ### Config model
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Before deploying to production, verify:
 - [ ] Tested against your specific OIDC provider (discovery, login, token exchange, refresh, logout)
 - [ ] HTTPS enforced in all environments (tokens travel over TLS)
 - [ ] Refresh token rotation enabled at your IdP (prevents stolen refresh token reuse)
-- [ ] `tokenExpirationBuffer` configured appropriately (default: 30 seconds)
+- [ ] `expiryBuffer` configured appropriately (default: 30 seconds)
 - [ ] CSP headers configured (mitigates XSS, the primary threat to SPA token storage)
 - [ ] `postLogoutRedirectUri` set correctly for your IdP
 - [ ] Error handling implemented for `OidcError` codes your app may encounter

--- a/decisions.md
+++ b/decisions.md
@@ -203,9 +203,9 @@ Architectural and design decisions for the oidc-js project. Each entry captures 
 
 **Context**: RequireAuth compares `tokens.expiresAt` to `Date.now()` to detect expired tokens. An exact comparison creates a race: a request can go out with a token that expires mid-flight.
 
-**Decision**: Add `tokenExpirationBuffer` prop on AuthProvider (default 30 seconds). RequireAuth treats the token as expired `buffer` seconds before actual expiration: `expiresAt - buffer > Date.now()`.
+**Decision**: Add `expiryBuffer` to `OidcConfig` (default 30 seconds). RequireAuth reads it from the provider config and treats the token as expired `buffer` seconds before actual expiration: `expiresAt - buffer > Date.now()`. Previously named `tokenExpirationBuffer` and set per-component; moved to global config for simplicity.
 
-**Rationale**: 30s default is conservative enough to cover most request round-trips without triggering unnecessary refreshes. Configurable for apps with different needs (long-running uploads, real-time connections).
+**Rationale**: 30s default is conservative enough to cover most request round-trips without triggering unnecessary refreshes. Configurable for apps with different needs (long-running uploads, real-time connections). A global config value avoids repetition across multiple guarded routes.
 
 ### 018 - `onError` callback on AuthProvider (2026-04-30)
 

--- a/docs-web/src/content/docs/guides/token-refresh.mdx
+++ b/docs-web/src/content/docs/guides/token-refresh.mdx
@@ -40,12 +40,12 @@ sequenceDiagram
 </RequireAuth>
 ```
 
-You can set a `tokenExpirationBuffer` (in seconds) to refresh the token early, accounting for clock skew and network latency. The default buffer is 30 seconds.
+You can set an `expiryBuffer` (in seconds) on the provider config to refresh the token early, accounting for clock skew and network latency. The default buffer is 30 seconds.
 
 ```tsx
-<RequireAuth tokenExpirationBuffer={60}>
-  <Dashboard />
-</RequireAuth>
+<AuthProvider config={{ ...config, expiryBuffer: 60 }}>
+  <App />
+</AuthProvider>
 ```
 
 ## Manual refresh

--- a/packages/angular/src/auth.guard.ts
+++ b/packages/angular/src/auth.guard.ts
@@ -1,12 +1,7 @@
 import { inject } from "@angular/core";
 import type { CanActivateFn } from "@angular/router";
 import { isExpiredAt } from "oidc-js-core";
-import { AuthService } from "./auth.service.js";
-
-export interface AuthGuardOptions {
-  /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
-  tokenExpirationBuffer?: number;
-}
+import { AuthService, AUTH_OPTIONS } from "./auth.service.js";
 
 /**
  * Creates a functional route guard that protects routes behind authentication.
@@ -25,16 +20,17 @@ export interface AuthGuardOptions {
  * ];
  * ```
  */
-export function createAuthGuard(options?: AuthGuardOptions): CanActivateFn {
+export function createAuthGuard(): CanActivateFn {
   return async (route, state) => {
     const auth = inject(AuthService);
+    const authOptions = inject(AUTH_OPTIONS);
 
     if (auth.isLoading()) {
       await waitForLoading(auth);
     }
 
     const tokens = auth.tokens();
-    const isExpired = isExpiredAt(tokens.expiresAt, options?.tokenExpirationBuffer);
+    const isExpired = isExpiredAt(tokens.expiresAt, authOptions.config.expiryBuffer);
 
     if (auth.isAuthenticated() && !isExpired) {
       return true;

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,6 +1,6 @@
 export { AuthService, AUTH_OPTIONS } from "./auth.service.js";
 export { provideAuth } from "./provide-auth.js";
-export { authGuard, createAuthGuard, type AuthGuardOptions } from "./auth.guard.js";
+export { authGuard, createAuthGuard } from "./auth.guard.js";
 
 export type {
   AuthProviderOptions,

--- a/packages/angular/src/tests/auth.guard.test.ts
+++ b/packages/angular/src/tests/auth.guard.test.ts
@@ -12,6 +12,8 @@ const { mockAuthService } = vi.hoisted(() => {
   return { mockAuthService };
 });
 
+const mockAuthOptions = { config: { issuer: "https://auth.example.com", clientId: "app" } };
+
 vi.mock("@angular/core", () => ({
   Injectable: () => (target: unknown) => target,
   InjectionToken: class {
@@ -25,7 +27,12 @@ vi.mock("@angular/core", () => ({
     fn.asReadonly = () => fn;
     return fn;
   },
-  inject: vi.fn().mockReturnValue(mockAuthService),
+  inject: vi.fn().mockImplementation((token: unknown) => {
+    if (token instanceof Object && "desc" in (token as Record<string, unknown>)) {
+      return mockAuthOptions;
+    }
+    return mockAuthService;
+  }),
 }));
 
 vi.mock("@angular/router", () => ({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,7 +18,7 @@ export { buildIntrospectRequest, parseIntrospectResponse } from "./introspect.js
 export { buildRevocationRequest } from "./revocation.js";
 export { buildLogoutUrl } from "./logout.js";
 export { decodeJwtPayload, parseIdTokenClaims } from "./jwt.js";
-export { nowSeconds, computeExpiresAt, timeUntilExpiry, isExpiredAt, DEFAULT_TOKEN_EXPIRATION_BUFFER } from "./token-utils.js";
+export { nowSeconds, computeExpiresAt, timeUntilExpiry, isExpiredAt, DEFAULT_EXPIRY_BUFFER, DEFAULT_TOKEN_EXPIRATION_BUFFER } from "./token-utils.js";
 export { buildClientAuthHeaders } from "./auth.js";
 
 export type {

--- a/packages/core/src/tests/token-utils.test.ts
+++ b/packages/core/src/tests/token-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { nowSeconds, computeExpiresAt, timeUntilExpiry, isExpiredAt, DEFAULT_TOKEN_EXPIRATION_BUFFER } from "../token-utils.js";
+import { nowSeconds, computeExpiresAt, timeUntilExpiry, isExpiredAt, DEFAULT_EXPIRY_BUFFER, DEFAULT_TOKEN_EXPIRATION_BUFFER } from "../token-utils.js";
 
 describe("computeExpiresAt", () => {
   beforeEach(() => {
@@ -54,10 +54,14 @@ describe("isExpiredAt", () => {
     expect(isExpiredAt(nowSeconds() + 1, 0)).toBe(false);
   });
 
-  it("defaults to DEFAULT_TOKEN_EXPIRATION_BUFFER (30s)", () => {
-    expect(DEFAULT_TOKEN_EXPIRATION_BUFFER).toBe(30);
+  it("defaults to DEFAULT_EXPIRY_BUFFER (30s)", () => {
+    expect(DEFAULT_EXPIRY_BUFFER).toBe(30);
     expect(isExpiredAt(nowSeconds() + 29)).toBe(true);
     expect(isExpiredAt(nowSeconds() + 31)).toBe(false);
+  });
+
+  it("DEFAULT_TOKEN_EXPIRATION_BUFFER is a deprecated alias", () => {
+    expect(DEFAULT_TOKEN_EXPIRATION_BUFFER).toBe(DEFAULT_EXPIRY_BUFFER);
   });
 });
 

--- a/packages/core/src/token-utils.ts
+++ b/packages/core/src/token-utils.ts
@@ -1,5 +1,8 @@
-/** Default token expiration buffer in seconds (30 seconds). */
-export const DEFAULT_TOKEN_EXPIRATION_BUFFER = 30;
+/** Default expiry buffer in seconds (30 seconds). */
+export const DEFAULT_EXPIRY_BUFFER = 30;
+
+/** @deprecated Use {@link DEFAULT_EXPIRY_BUFFER} instead. */
+export const DEFAULT_TOKEN_EXPIRATION_BUFFER = DEFAULT_EXPIRY_BUFFER;
 
 /** Returns the current time as a Unix timestamp in seconds. */
 export function nowSeconds(): number {
@@ -24,7 +27,7 @@ export function computeExpiresAt(expiresIn: number): number {
  * @param bufferSeconds - Buffer in seconds subtracted from expiry to account for clock skew and network latency.
  * @returns `true` if the current time is at or past the buffered expiry time.
  */
-export function isExpiredAt(expiresAt: number | null, bufferSeconds: number = DEFAULT_TOKEN_EXPIRATION_BUFFER): boolean {
+export function isExpiredAt(expiresAt: number | null, bufferSeconds: number = DEFAULT_EXPIRY_BUFFER): boolean {
   if (expiresAt === null) return false;
   return nowSeconds() >= expiresAt - bufferSeconds;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,6 +17,8 @@ export interface OidcConfig {
   scopes?: string[];
   /** URI to redirect to after logout (OpenID Connect RP-Initiated Logout 1.0). */
   postLogoutRedirectUri?: string;
+  /** Buffer in seconds before token expiry to consider the token expired. Defaults to 30. */
+  expiryBuffer?: number;
 }
 
 /**

--- a/packages/kasper/src/require-auth.ts
+++ b/packages/kasper/src/require-auth.ts
@@ -6,7 +6,6 @@ import { useAuth } from "./context.js";
 interface RequireAuthArgs {
   autoRefresh?: boolean;
   loginOptions?: LoginOptions;
-  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -30,7 +29,7 @@ export class RequireAuth extends Component<RequireAuthArgs> {
 
   _ready(): boolean {
     const auth = useAuth();
-    const isExpired = isExpiredAt(auth.tokens.value.expiresAt, this.args.tokenExpirationBuffer);
+    const isExpired = isExpiredAt(auth.tokens.value.expiresAt, auth.config.expiryBuffer);
     return (
       !auth.isLoading.value && auth.isAuthenticated.value && !isExpired
     );
@@ -41,7 +40,7 @@ export class RequireAuth extends Component<RequireAuthArgs> {
     const autoRefresh = this.args.autoRefresh ?? true;
 
     this.effect(() => {
-      const isExpired = isExpiredAt(auth.tokens.value.expiresAt, this.args.tokenExpirationBuffer);
+      const isExpired = isExpiredAt(auth.tokens.value.expiresAt, auth.config.expiryBuffer);
       const needsAuth = !auth.isAuthenticated.value || isExpired;
 
       if (!needsAuth) {

--- a/packages/lit/src/require-auth.ts
+++ b/packages/lit/src/require-auth.ts
@@ -13,8 +13,6 @@ export interface RequireAuthOptions {
   autoRefresh?: boolean;
   /** Additional options passed to the login redirect if authentication is required. */
   loginOptions?: LoginOptions;
-  /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
-  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -55,7 +53,6 @@ export class RequireAuthController implements ReactiveController {
   private auth: AuthController;
   private autoRefresh: boolean;
   private loginOptions?: LoginOptions;
-  private tokenExpirationBuffer?: number;
   private refreshAttempted = false;
 
   /**
@@ -69,7 +66,6 @@ export class RequireAuthController implements ReactiveController {
     this.auth = options.auth;
     this.autoRefresh = options.autoRefresh ?? true;
     this.loginOptions = options.loginOptions;
-    this.tokenExpirationBuffer = options.tokenExpirationBuffer;
     host.addController(this);
   }
 
@@ -79,7 +75,7 @@ export class RequireAuthController implements ReactiveController {
    */
   get authorized(): boolean {
     const { isAuthenticated, isLoading, tokens } = this.auth;
-    const isExpired = isExpiredAt(tokens.expiresAt, this.tokenExpirationBuffer);
+    const isExpired = isExpiredAt(tokens.expiresAt, this.auth.config.expiryBuffer);
     return isAuthenticated && !isExpired && !isLoading;
   }
 
@@ -99,7 +95,7 @@ export class RequireAuthController implements ReactiveController {
    */
   hostUpdated(): void {
     const { isAuthenticated, isLoading, tokens } = this.auth;
-    const isExpired = isExpiredAt(tokens.expiresAt, this.tokenExpirationBuffer);
+    const isExpired = isExpiredAt(tokens.expiresAt, this.auth.config.expiryBuffer);
     const needsAuth = !isAuthenticated || isExpired;
 
     if (!needsAuth) {

--- a/packages/preact/src/auth-required.tsx
+++ b/packages/preact/src/auth-required.tsx
@@ -9,7 +9,6 @@ interface RequireAuthProps {
   fallback?: ComponentChildren;
   autoRefresh?: boolean;
   loginOptions?: LoginOptions;
-  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -26,12 +25,11 @@ export function RequireAuth({
   fallback = null,
   autoRefresh = true,
   loginOptions,
-  tokenExpirationBuffer,
 }: RequireAuthProps) {
-  const { isAuthenticated, isLoading, tokens, actions } = useAuth();
+  const { isAuthenticated, isLoading, tokens, actions, config } = useAuth();
   const refreshAttempted = useRef(false);
 
-  const isExpired = isExpiredAt(tokens.expiresAt, tokenExpirationBuffer);
+  const isExpired = isExpiredAt(tokens.expiresAt, config.expiryBuffer);
   const needsAuth = !isAuthenticated || isExpired;
 
   useEffect(() => {

--- a/packages/react/src/auth-required.tsx
+++ b/packages/react/src/auth-required.tsx
@@ -8,7 +8,6 @@ interface RequireAuthProps {
   fallback?: ReactNode;
   autoRefresh?: boolean;
   loginOptions?: LoginOptions;
-  tokenExpirationBuffer?: number;
 }
 
 export function RequireAuth({
@@ -16,12 +15,11 @@ export function RequireAuth({
   fallback = null,
   autoRefresh = true,
   loginOptions,
-  tokenExpirationBuffer,
 }: RequireAuthProps) {
-  const { isAuthenticated, isLoading, tokens, actions } = useAuth();
+  const { isAuthenticated, isLoading, tokens, actions, config } = useAuth();
   const refreshAttempted = useRef(false);
 
-  const isExpired = isExpiredAt(tokens.expiresAt, tokenExpirationBuffer);
+  const isExpired = isExpiredAt(tokens.expiresAt, config.expiryBuffer);
   const needsAuth = !isAuthenticated || isExpired;
 
   useEffect(() => {

--- a/packages/solid/src/auth-required.tsx
+++ b/packages/solid/src/auth-required.tsx
@@ -13,8 +13,6 @@ interface RequireAuthProps {
   autoRefresh?: boolean;
   /** Additional options passed to the login redirect. */
   loginOptions?: LoginOptions;
-  /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
-  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -35,7 +33,7 @@ export const RequireAuth: ParentComponent<RequireAuthProps> = (props) => {
   let refreshAttempted = false;
 
   createEffect(() => {
-    const isExpired = isExpiredAt(auth.tokens.expiresAt, props.tokenExpirationBuffer);
+    const isExpired = isExpiredAt(auth.tokens.expiresAt, auth.config.expiryBuffer);
     const needsAuth = !auth.isAuthenticated || isExpired;
 
     if (!needsAuth) {
@@ -57,7 +55,7 @@ export const RequireAuth: ParentComponent<RequireAuthProps> = (props) => {
 
   return (
     <Show
-      when={!auth.isLoading && auth.isAuthenticated && !isExpiredAt(auth.tokens.expiresAt, props.tokenExpirationBuffer)}
+      when={!auth.isLoading && auth.isAuthenticated && !isExpiredAt(auth.tokens.expiresAt, auth.config.expiryBuffer)}
       fallback={props.fallback}
     >
       {props.children}

--- a/packages/svelte/src/RequireAuth.svelte
+++ b/packages/svelte/src/RequireAuth.svelte
@@ -33,17 +33,15 @@
     autoRefresh?: boolean;
     /** Options to pass to the login redirect if authentication is required. */
     loginOptions?: LoginOptions;
-    /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
-    tokenExpirationBuffer?: number;
   }
 
-  let { children, fallback, autoRefresh = true, loginOptions, tokenExpirationBuffer }: Props = $props();
+  let { children, fallback, autoRefresh = true, loginOptions }: Props = $props();
 
   const auth = getAuthContext();
   let refreshAttempted = false;
 
   $effect(() => {
-    const isExpired = isExpiredAt(auth.tokens.expiresAt, tokenExpirationBuffer);
+    const isExpired = isExpiredAt(auth.tokens.expiresAt, auth.config.expiryBuffer);
     const needsAuth = !auth.isAuthenticated || isExpired;
 
     if (!needsAuth) {
@@ -62,7 +60,7 @@
   });
 </script>
 
-{#if auth.isLoading || !auth.isAuthenticated || isExpiredAt(auth.tokens.expiresAt, tokenExpirationBuffer)}
+{#if auth.isLoading || !auth.isAuthenticated || isExpiredAt(auth.tokens.expiresAt, auth.config.expiryBuffer)}
   {#if fallback}
     {@render fallback()}
   {/if}

--- a/packages/vue/src/auth-required.ts
+++ b/packages/vue/src/auth-required.ts
@@ -37,20 +37,15 @@ export const RequireAuth = defineComponent({
       type: Object as PropType<LoginOptions>,
       default: undefined,
     },
-    /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
-    tokenExpirationBuffer: {
-      type: Number,
-      default: undefined,
-    },
   },
   setup(props, { slots }) {
-    const { isAuthenticated, isLoading, tokens, actions } = useAuth();
+    const { isAuthenticated, isLoading, tokens, actions, config } = useAuth();
     const refreshAttempted = ref(false);
 
     watch(
       [isAuthenticated, isLoading, tokens],
       () => {
-        const isExpired = isExpiredAt(tokens.value.expiresAt, props.tokenExpirationBuffer);
+        const isExpired = isExpiredAt(tokens.value.expiresAt, config.expiryBuffer);
         const needsAuth = !isAuthenticated.value || isExpired;
 
         if (!needsAuth) {
@@ -72,7 +67,7 @@ export const RequireAuth = defineComponent({
     );
 
     return (): VNode | VNode[] | null => {
-      const isExpired = isExpiredAt(tokens.value.expiresAt, props.tokenExpirationBuffer);
+      const isExpired = isExpiredAt(tokens.value.expiresAt, config.expiryBuffer);
       const needsAuth = !isAuthenticated.value || isExpired;
 
       if (isLoading.value || needsAuth) {

--- a/packages/vue/src/guard.ts
+++ b/packages/vue/src/guard.ts
@@ -9,8 +9,6 @@ import { isExpiredAt } from "oidc-js-core";
 export interface AuthGuardOptions {
   /** Options to pass to the login method when redirecting unauthenticated users. */
   loginOptions?: LoginOptions;
-  /** Buffer in milliseconds before token expiry to consider it expired. Defaults to 30000. */
-  tokenExpirationBuffer?: number;
 }
 
 /**
@@ -62,7 +60,7 @@ export function createAuthGuard(
       });
     }
 
-    const isExpired = isExpiredAt(context.tokens.value.expiresAt, options?.tokenExpirationBuffer);
+    const isExpired = isExpiredAt(context.tokens.value.expiresAt, context.config.expiryBuffer);
 
     if (context.isAuthenticated.value && !isExpired) {
       next();


### PR DESCRIPTION
## Summary

- Add `expiryBuffer` to `OidcConfig` in core so it's configured once at the provider level
- Remove per-component `tokenExpirationBuffer` prop from all 8 framework adapters (React, Angular, Vue, Svelte, Solid, Preact, Lit, Kasper)
- Guards now read the buffer from config context instead of their own props
- Rename `DEFAULT_TOKEN_EXPIRATION_BUFFER` to `DEFAULT_EXPIRY_BUFFER` (deprecated alias kept)

Closes #51

## Test plan

- [x] Core unit tests pass (including deprecated alias test)
- [x] Angular guard tests updated for new inject pattern
- [x] All packages build successfully (including e2e test apps)
- [ ] Run e2e tests to verify token refresh buffer behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)