### PR TITLE
docs: streamline landing page and quickstart

### DIFF
--- a/docs-web/src/content/docs/getting-started/quickstart.mdx
+++ b/docs-web/src/content/docs/getting-started/quickstart.mdx
@@ -5,186 +5,24 @@ description: Get up and running with oidc-js in 5 minutes.
 
 import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 
-This guide walks through adding OIDC authentication to your app. You'll need an OIDC provider (like [Autentico](https://autentico.top), Auth0, Keycloak, or any spec-compliant IdP).
+This guide walks through adding OIDC authentication to your app using any spec-compliant OIDC provider (like [Autentico](https://autentico.top), Auth0, or Keycloak).
 
 <Steps>
 
-1. **Install the package**
+1. **Install your framework adapter**
 
-   <Tabs>
-     <TabItem label="React">
-     <Tabs>
-       <TabItem label="npm">
-       ```bash
-       npm install oidc-js-react
-       ```
-       </TabItem>
-       <TabItem label="pnpm">
-       ```bash
-       pnpm add oidc-js-react
-       ```
-       </TabItem>
-       <TabItem label="yarn">
-       ```bash
-       yarn add oidc-js-react
-       ```
-       </TabItem>
-     </Tabs>
-     </TabItem>
-     <TabItem label="Vue">
-     <Tabs>
-       <TabItem label="npm">
-       ```bash
-       npm install oidc-js-vue
-       ```
-       </TabItem>
-       <TabItem label="pnpm">
-       ```bash
-       pnpm add oidc-js-vue
-       ```
-       </TabItem>
-       <TabItem label="yarn">
-       ```bash
-       yarn add oidc-js-vue
-       ```
-       </TabItem>
-     </Tabs>
-     </TabItem>
-     <TabItem label="Svelte">
-     <Tabs>
-       <TabItem label="npm">
-       ```bash
-       npm install oidc-js-svelte
-       ```
-       </TabItem>
-       <TabItem label="pnpm">
-       ```bash
-       pnpm add oidc-js-svelte
-       ```
-       </TabItem>
-       <TabItem label="yarn">
-       ```bash
-       yarn add oidc-js-svelte
-       ```
-       </TabItem>
-     </Tabs>
-     </TabItem>
-     <TabItem label="Angular">
-     <Tabs>
-       <TabItem label="npm">
-       ```bash
-       npm install oidc-js-angular
-       ```
-       </TabItem>
-       <TabItem label="pnpm">
-       ```bash
-       pnpm add oidc-js-angular
-       ```
-       </TabItem>
-       <TabItem label="yarn">
-       ```bash
-       yarn add oidc-js-angular
-       ```
-       </TabItem>
-     </Tabs>
-     </TabItem>
-     <TabItem label="Solid">
-     <Tabs>
-       <TabItem label="npm">
-       ```bash
-       npm install oidc-js-solid
-       ```
-       </TabItem>
-       <TabItem label="pnpm">
-       ```bash
-       pnpm add oidc-js-solid
-       ```
-       </TabItem>
-       <TabItem label="yarn">
-       ```bash
-       yarn add oidc-js-solid
-       ```
-       </TabItem>
-     </Tabs>
-     </TabItem>
-     <TabItem label="Preact">
-     <Tabs>
-       <TabItem label="npm">
-       ```bash
-       npm install oidc-js-preact
-       ```
-       </TabItem>
-       <TabItem label="pnpm">
-       ```bash
-       pnpm add oidc-js-preact
-       ```
-       </TabItem>
-       <TabItem label="yarn">
-       ```bash
-       yarn add oidc-js-preact
-       ```
-       </TabItem>
-     </Tabs>
-     </TabItem>
-     <TabItem label="Lit">
-     <Tabs>
-       <TabItem label="npm">
-       ```bash
-       npm install oidc-js-lit
-       ```
-       </TabItem>
-       <TabItem label="pnpm">
-       ```bash
-       pnpm add oidc-js-lit
-       ```
-       </TabItem>
-       <TabItem label="yarn">
-       ```bash
-       yarn add oidc-js-lit
-       ```
-       </TabItem>
-     </Tabs>
-     </TabItem>
-     <TabItem label="Kasper">
-     <Tabs>
-       <TabItem label="npm">
-       ```bash
-       npm install oidc-js-kasper
-       ```
-       </TabItem>
-       <TabItem label="pnpm">
-       ```bash
-       pnpm add oidc-js-kasper
-       ```
-       </TabItem>
-       <TabItem label="yarn">
-       ```bash
-       yarn add oidc-js-kasper
-       ```
-       </TabItem>
-     </Tabs>
-     </TabItem>
-   </Tabs>
+   ```bash
+   npm install oidc-js-react  # or oidc-js-vue, oidc-js-svelte, oidc-js-angular, etc.
+   ```
 
-2. **Configure the provider**
+2. **Add authentication**
 
-   You'll need these values from your IdP:
-   - **Issuer URL** — the base URL of your OIDC provider (e.g. `https://auth.example.com`)
-   - **Client ID** — registered in your IdP's client/application settings
-   - **Redirect URI** — where the IdP sends the user after login (must be registered)
-
-3. **Wrap your app with the auth provider**
+   You'll need an **issuer URL**, **client ID**, and **redirect URI** from your OIDC provider.
 
    <Tabs>
      <TabItem label="React">
      ```tsx
-     // main.tsx
-     import { StrictMode } from "react";
-     import { createRoot } from "react-dom/client";
-     import { BrowserRouter, useNavigate } from "react-router";
-     import { AuthProvider } from "oidc-js-react";
-     import { useCallback } from "react";
-     import App from "./App";
+     import { AuthProvider, RequireAuth, useAuth } from "oidc-js-react";
 
      const config = {
        issuer: "https://auth.example.com",
@@ -193,43 +31,31 @@ This guide walks through adding OIDC authentication to your app. You'll need an 
        scopes: ["openid", "profile", "email", "offline_access"],
      };
 
-     function Root() {
-       const navigate = useNavigate();
-       const onLogin = useCallback(
-         (returnTo: string) => navigate(returnTo, { replace: true }),
-         [navigate],
-       );
-
+     function App() {
        return (
-         <AuthProvider config={config} onLogin={onLogin}>
-           <App />
+         <AuthProvider config={config}>
+           <RequireAuth fallback={<p>Loading...</p>}>
+             <Dashboard />
+           </RequireAuth>
          </AuthProvider>
        );
      }
 
-     createRoot(document.getElementById("root")!).render(
-       <StrictMode>
-         <BrowserRouter>
-           <Root />
-         </BrowserRouter>
-       </StrictMode>,
-     );
+     function Dashboard() {
+       const { user, actions } = useAuth();
+       return (
+         <div>
+           <p>Welcome, {user?.profile?.name}!</p>
+           <button onClick={() => actions.logout()}>Log out</button>
+         </div>
+       );
+     }
      ```
      </TabItem>
      <TabItem label="Vue">
      ```ts
-     // main.ts
-     import { createApp } from "vue";
-     import { createRouter, createWebHistory } from "vue-router";
+     // main.ts — register the plugin
      import { oidcPlugin } from "oidc-js-vue";
-     import App from "./App.vue";
-
-     const router = createRouter({
-       history: createWebHistory(),
-       routes: [/* your routes */],
-     });
-
-     const app = createApp(App);
 
      app.use(oidcPlugin, {
        config: {
@@ -238,20 +64,30 @@ This guide walks through adding OIDC authentication to your app. You'll need an 
          redirectUri: "http://localhost:5173/callback",
          scopes: ["openid", "profile", "email", "offline_access"],
        },
-       onLogin(returnTo: string) {
-         router.replace(returnTo);
-       },
      });
+     ```
 
-     app.use(router);
-     app.mount("#app");
+     ```vue
+     <!-- Dashboard.vue — protect and access auth state -->
+     <script setup lang="ts">
+     import { RequireAuth, useAuth } from "oidc-js-vue";
+     const { user, actions } = useAuth();
+     </script>
+
+     <template>
+       <RequireAuth>
+         <template #fallback><p>Loading...</p></template>
+         <p>Welcome, {{ user?.profile?.name }}!</p>
+         <button @click="actions.logout()">Log out</button>
+       </RequireAuth>
+     </template>
      ```
      </TabItem>
      <TabItem label="Svelte">
      ```svelte
      <!-- App.svelte -->
      <script lang="ts">
-       import { AuthProvider } from "oidc-js-svelte";
+       import { AuthProvider, RequireAuth } from "oidc-js-svelte";
 
        const config = {
          issuer: "https://auth.example.com",
@@ -259,31 +95,47 @@ This guide walks through adding OIDC authentication to your app. You'll need an 
          redirectUri: "http://localhost:5173/callback",
          scopes: ["openid", "profile", "email", "offline_access"],
        };
-
-       function handleLogin(returnTo: string) {
-         window.history.replaceState({}, "", returnTo);
-       }
      </script>
 
-     <AuthProvider {config} onLogin={handleLogin}>
+     <AuthProvider {config}>
        {#snippet children()}
-         <slot />
+         <RequireAuth>
+           {#snippet children()}
+             <Dashboard />
+           {/snippet}
+           {#snippet fallback()}
+             <p>Loading...</p>
+           {/snippet}
+         </RequireAuth>
        {/snippet}
      </AuthProvider>
+     ```
+
+     ```svelte
+     <!-- Dashboard.svelte — access auth state -->
+     <script lang="ts">
+       import { getAuthContext } from "oidc-js-svelte";
+       const auth = getAuthContext();
+     </script>
+
+     <p>Welcome, {auth.user?.profile?.name}!</p>
+     <button onclick={() => auth.actions.logout()}>Log out</button>
      ```
      </TabItem>
      <TabItem label="Angular">
      ```ts
-     // main.ts
-     import { bootstrapApplication } from "@angular/platform-browser";
-     import { provideRouter } from "@angular/router";
-     import { provideAuth } from "oidc-js-angular";
-     import { AppComponent } from "./app/app.component";
-     import { routes } from "./app/app.routes";
+     // app.config.ts — provide auth and protect routes
+     import { provideAuth, authGuard } from "oidc-js-angular";
 
-     bootstrapApplication(AppComponent, {
+     export const appConfig = {
        providers: [
-         provideRouter(routes),
+         provideRouter([
+           {
+             path: "dashboard",
+             component: DashboardComponent,
+             canActivate: [authGuard],
+           },
+         ]),
          provideAuth({
            config: {
              issuer: "https://auth.example.com",
@@ -293,15 +145,29 @@ This guide walks through adding OIDC authentication to your app. You'll need an 
            },
          }),
        ],
-     });
+     };
+     ```
+
+     ```ts
+     // dashboard.component.ts — access auth state
+     import { Component, inject } from "@angular/core";
+     import { AuthService } from "oidc-js-angular";
+
+     @Component({
+       selector: "app-dashboard",
+       template: `
+         <p>Welcome, {{ auth.user()?.profile?.name }}!</p>
+         <button (click)="auth.logout()">Log out</button>
+       `,
+     })
+     export class DashboardComponent {
+       readonly auth = inject(AuthService);
+     }
      ```
      </TabItem>
      <TabItem label="Solid">
      ```tsx
-     // App.tsx
-     import { useNavigate } from "@solidjs/router";
-     import { AuthProvider } from "oidc-js-solid";
-     import type { ParentComponent } from "solid-js";
+     import { AuthProvider, RequireAuth, useAuth } from "oidc-js-solid";
 
      const config = {
        issuer: "https://auth.example.com",
@@ -310,57 +176,64 @@ This guide walks through adding OIDC authentication to your app. You'll need an 
        scopes: ["openid", "profile", "email", "offline_access"],
      };
 
-     export const App: ParentComponent = (props) => {
-       const navigate = useNavigate();
-       const onLogin = (returnTo: string) => {
-         navigate(returnTo, { replace: true });
-       };
-
+     function App() {
        return (
-         <AuthProvider config={config} onLogin={onLogin}>
-           {props.children}
-         </AuthProvider>
-       );
-     };
-     ```
-     </TabItem>
-     <TabItem label="Preact">
-     ```tsx
-     // index.tsx
-     import { render } from "preact";
-     import { AuthProvider } from "oidc-js-preact";
-     import { route } from "preact-router";
-     import { useCallback } from "preact/hooks";
-     import { App } from "./App";
-
-     const config = {
-       issuer: "https://auth.example.com",
-       clientId: "my-app",
-       redirectUri: "http://localhost:5173/callback",
-       scopes: ["openid", "profile", "email", "offline_access"],
-     };
-
-     function Root() {
-       const onLogin = useCallback((returnTo: string) => {
-         route(returnTo, true);
-       }, []);
-
-       return (
-         <AuthProvider config={config} onLogin={onLogin}>
-           <App />
+         <AuthProvider config={config}>
+           <RequireAuth fallback={<p>Loading...</p>}>
+             <Dashboard />
+           </RequireAuth>
          </AuthProvider>
        );
      }
 
-     render(<Root />, document.getElementById("root")!);
+     function Dashboard() {
+       const auth = useAuth();
+       return (
+         <div>
+           <p>Welcome, {auth.user?.profile?.name}!</p>
+           <button onClick={() => auth.actions.logout()}>Log out</button>
+         </div>
+       );
+     }
+     ```
+     </TabItem>
+     <TabItem label="Preact">
+     ```tsx
+     import { AuthProvider, RequireAuth, useAuth } from "oidc-js-preact";
+
+     const config = {
+       issuer: "https://auth.example.com",
+       clientId: "my-app",
+       redirectUri: "http://localhost:5173/callback",
+       scopes: ["openid", "profile", "email", "offline_access"],
+     };
+
+     function App() {
+       return (
+         <AuthProvider config={config}>
+           <RequireAuth fallback={<p>Loading...</p>}>
+             <Dashboard />
+           </RequireAuth>
+         </AuthProvider>
+       );
+     }
+
+     function Dashboard() {
+       const { user, actions } = useAuth();
+       return (
+         <div>
+           <p>Welcome, {user?.profile?.name}!</p>
+           <button onClick={() => actions.logout()}>Log out</button>
+         </div>
+       );
+     }
      ```
      </TabItem>
      <TabItem label="Lit">
      ```ts
-     // app-root.ts
      import { LitElement, html } from "lit";
      import { customElement } from "lit/decorators.js";
-     import { AuthController } from "oidc-js-lit";
+     import { AuthController, RequireAuthController } from "oidc-js-lit";
 
      @customElement("app-root")
      export class AppRoot extends LitElement {
@@ -371,226 +244,14 @@ This guide walks through adding OIDC authentication to your app. You'll need an 
            redirectUri: "http://localhost:5173/callback",
            scopes: ["openid", "profile", "email", "offline_access"],
          },
-         onLogin: (returnTo: string) => {
-           window.history.replaceState({}, "", returnTo);
-         },
        });
+       guard = new RequireAuthController(this, { auth: this.auth });
 
        render() {
-         return html`<home-page .auth=${this.auth}></home-page>`;
-       }
-     }
-     ```
-     </TabItem>
-     <TabItem label="Kasper">
-     ```ts
-     // main.ts
-     import { App } from "kasper-js";
-     import { AppRoot } from "./components/App.kasper";
-     import { AuthProvider, RequireAuth } from "oidc-js-kasper";
-
-     App({
-       root: document.getElementById("root")!,
-       entry: "app-root",
-       registry: {
-         "app-root": { component: AppRoot },
-         "auth-provider": { component: AuthProvider },
-         "require-auth": { component: RequireAuth },
-       },
-     });
-     ```
-
-     ```html
-     <!-- App.kasper -->
-     <template>
-       <auth-provider @:config="config" @:onLogin="handleLogin">
-         <slot />
-       </auth-provider>
-     </template>
-
-     <script>
-     import { Component, navigate } from "kasper-js";
-
-     export class AppRoot extends Component {
-       config = {
-         issuer: "https://auth.example.com",
-         clientId: "my-app",
-         redirectUri: "http://localhost:5173/callback",
-         scopes: ["openid", "profile", "email", "offline_access"],
-       };
-
-       handleLogin = (returnTo) => {
-         navigate(returnTo);
-       };
-     }
-     </script>
-     ```
-     </TabItem>
-   </Tabs>
-
-4. **Access auth state**
-
-   <Tabs>
-     <TabItem label="React">
-     ```tsx
-     // App.tsx
-     import { useAuth } from "oidc-js-react";
-
-     function App() {
-       const { isAuthenticated, isLoading, user, actions } = useAuth();
-
-       if (isLoading) return <div>Loading...</div>;
-
-       if (!isAuthenticated) {
-         return <button onClick={() => actions.login()}>Log in</button>;
-       }
-
-       return (
-         <div>
-           <p>Welcome, {user?.profile?.name ?? user?.claims.sub}!</p>
-           <button onClick={() => actions.logout()}>Log out</button>
-         </div>
-       );
-     }
-     ```
-     </TabItem>
-     <TabItem label="Vue">
-     ```vue
-     <!-- Home.vue -->
-     <script setup lang="ts">
-     import { useAuth } from "oidc-js-vue";
-
-     const { user, isAuthenticated, isLoading, actions } = useAuth();
-     </script>
-
-     <template>
-       <div v-if="isLoading">Loading...</div>
-       <div v-else-if="!isAuthenticated">
-         <button @click="actions.login()">Log in</button>
-       </div>
-       <div v-else>
-         <p>Welcome, {{ user?.profile?.name ?? user?.claims.sub }}!</p>
-         <button @click="actions.logout()">Log out</button>
-       </div>
-     </template>
-     ```
-     </TabItem>
-     <TabItem label="Svelte">
-     ```svelte
-     <!-- Home.svelte -->
-     <script lang="ts">
-       import { getAuthContext } from "oidc-js-svelte";
-
-       const auth = getAuthContext();
-     </script>
-
-     {#if auth.isLoading}
-       <div>Loading...</div>
-     {:else if !auth.isAuthenticated}
-       <button onclick={() => auth.actions.login()}>Log in</button>
-     {:else}
-       <p>Welcome, {auth.user?.profile?.name ?? auth.user?.claims.sub}!</p>
-       <button onclick={() => auth.actions.logout()}>Log out</button>
-     {/if}
-     ```
-     </TabItem>
-     <TabItem label="Angular">
-     ```ts
-     // home.component.ts
-     import { Component, inject } from "@angular/core";
-     import { AuthService } from "oidc-js-angular";
-
-     @Component({
-       selector: "app-home",
-       standalone: true,
-       template: `
-         @if (auth.isLoading()) {
-           <div>Loading...</div>
-         } @else if (!auth.isAuthenticated()) {
-           <button (click)="auth.login()">Log in</button>
-         } @else {
-           <p>Welcome, {{ auth.user()?.profile?.name ?? auth.user()?.claims?.sub }}!</p>
-           <button (click)="auth.logout()">Log out</button>
-         }
-       `,
-     })
-     export class HomeComponent {
-       readonly auth = inject(AuthService);
-     }
-     ```
-     </TabItem>
-     <TabItem label="Solid">
-     ```tsx
-     // Home.tsx
-     import { Show } from "solid-js";
-     import { useAuth } from "oidc-js-solid";
-
-     export function Home() {
-       const auth = useAuth();
-
-       return (
-         <Show
-           when={!auth.isLoading}
-           fallback={<div>Loading...</div>}
-         >
-           <Show when={!auth.isAuthenticated}>
-             <button onClick={() => auth.actions.login()}>Log in</button>
-           </Show>
-           <Show when={auth.isAuthenticated}>
-             <p>Welcome, {auth.user?.profile?.name ?? auth.user?.claims.sub}!</p>
-             <button onClick={() => auth.actions.logout()}>Log out</button>
-           </Show>
-         </Show>
-       );
-     }
-     ```
-     </TabItem>
-     <TabItem label="Preact">
-     ```tsx
-     // Home.tsx
-     import { useAuth } from "oidc-js-preact";
-
-     export function Home() {
-       const { isAuthenticated, isLoading, user, actions } = useAuth();
-
-       if (isLoading) return <div>Loading...</div>;
-
-       if (!isAuthenticated) {
-         return <button onClick={() => actions.login()}>Log in</button>;
-       }
-
-       return (
-         <div>
-           <p>Welcome, {user?.profile?.name ?? user?.claims.sub}!</p>
-           <button onClick={() => actions.logout()}>Log out</button>
-         </div>
-       );
-     }
-     ```
-     </TabItem>
-     <TabItem label="Lit">
-     ```ts
-     // home-page.ts
-     import { LitElement, html } from "lit";
-     import { customElement, property } from "lit/decorators.js";
-     import type { AuthController } from "oidc-js-lit";
-
-     @customElement("home-page")
-     export class HomePage extends LitElement {
-       @property({ attribute: false })
-       auth!: AuthController;
-
-       render() {
-         const { user, isAuthenticated, isLoading } = this.auth;
-
-         if (isLoading) return html`<div>Loading...</div>`;
-
-         if (!isAuthenticated) {
-           return html`<button @click=${() => this.auth.login()}>Log in</button>`;
-         }
-
+         if (!this.guard.authorized) return html`<p>Loading...</p>`;
+         const { user } = this.auth;
          return html`
-           <p>Welcome, ${user?.profile?.name ?? user?.claims.sub}!</p>
+           <p>Welcome, ${user?.profile?.name}!</p>
            <button @click=${() => this.auth.logout()}>Log out</button>
          `;
        }
@@ -599,163 +260,28 @@ This guide walks through adding OIDC authentication to your app. You'll need an 
      </TabItem>
      <TabItem label="Kasper">
      ```html
-     <!-- Home.kasper -->
      <template>
-       <div @if="auth.isLoading.value">Loading...</div>
-       <div @elseif="!auth.isAuthenticated.value">
-         <button @on:click="auth.actions.login()">Log in</button>
-       </div>
-       <div @else>
-         <p>Welcome, {{auth.user.value?.profile?.name ?? auth.user.value?.claims.sub}}!</p>
-         <button @on:click="auth.actions.logout()">Log out</button>
-       </div>
+       <auth-provider @:config="config">
+         <require-auth>
+           <p>Welcome, {{auth.user.value?.profile?.name}}!</p>
+           <button @on:click="auth.actions.logout()">Log out</button>
+         </require-auth>
+       </auth-provider>
      </template>
 
      <script>
      import { Component } from "kasper-js";
      import { useAuth } from "oidc-js-kasper";
 
-     export class HomePage extends Component {
+     export class App extends Component {
+       config = {
+         issuer: "https://auth.example.com",
+         clientId: "my-app",
+         redirectUri: "http://localhost:5173/callback",
+         scopes: ["openid", "profile", "email", "offline_access"],
+       };
        auth = useAuth();
      }
-     </script>
-     ```
-     </TabItem>
-   </Tabs>
-
-5. **Protect routes**
-
-   <Tabs>
-     <TabItem label="React">
-     ```tsx
-     import { RequireAuth } from "oidc-js-react";
-
-     function ProtectedPage() {
-       return (
-         <RequireAuth fallback={<div>Loading...</div>}>
-           <p>This content is only visible to authenticated users.</p>
-         </RequireAuth>
-       );
-     }
-     ```
-     </TabItem>
-     <TabItem label="Vue">
-     ```vue
-     <!-- Protected.vue -->
-     <script setup lang="ts">
-     import { RequireAuth } from "oidc-js-vue";
-     </script>
-
-     <template>
-       <RequireAuth>
-         <template #fallback>
-           <div>Loading...</div>
-         </template>
-         <p>This content is only visible to authenticated users.</p>
-       </RequireAuth>
-     </template>
-     ```
-     </TabItem>
-     <TabItem label="Svelte">
-     ```svelte
-     <!-- Protected.svelte -->
-     <script lang="ts">
-       import { RequireAuth } from "oidc-js-svelte";
-     </script>
-
-     <RequireAuth>
-       {#snippet children()}
-         <p>This content is only visible to authenticated users.</p>
-       {/snippet}
-       {#snippet fallback()}
-         <div>Loading...</div>
-       {/snippet}
-     </RequireAuth>
-     ```
-     </TabItem>
-     <TabItem label="Angular">
-     ```ts
-     // app.routes.ts
-     import type { Routes } from "@angular/router";
-     import { authGuard } from "oidc-js-angular";
-
-     export const routes: Routes = [
-       { path: "", component: HomeComponent },
-       {
-         path: "protected",
-         component: ProtectedComponent,
-         canActivate: [authGuard],
-       },
-     ];
-     ```
-     </TabItem>
-     <TabItem label="Solid">
-     ```tsx
-     import { RequireAuth } from "oidc-js-solid";
-
-     function ProtectedPage() {
-       return (
-         <RequireAuth fallback={<div>Loading...</div>}>
-           <p>This content is only visible to authenticated users.</p>
-         </RequireAuth>
-       );
-     }
-     ```
-     </TabItem>
-     <TabItem label="Preact">
-     ```tsx
-     import { RequireAuth } from "oidc-js-preact";
-
-     function ProtectedPage() {
-       return (
-         <RequireAuth fallback={<div>Loading...</div>}>
-           <p>This content is only visible to authenticated users.</p>
-         </RequireAuth>
-       );
-     }
-     ```
-     </TabItem>
-     <TabItem label="Lit">
-     ```ts
-     import { LitElement, html } from "lit";
-     import { customElement, property } from "lit/decorators.js";
-     import { AuthController, RequireAuthController } from "oidc-js-lit";
-
-     @customElement("protected-page")
-     export class ProtectedPage extends LitElement {
-       @property({ attribute: false })
-       auth!: AuthController;
-
-       private guard!: RequireAuthController;
-
-       connectedCallback() {
-         this.guard = new RequireAuthController(this, { auth: this.auth });
-         super.connectedCallback();
-       }
-
-       render() {
-         if (!this.guard.authorized) {
-           return html`<div>Loading...</div>`;
-         }
-         return html`<p>This content is only visible to authenticated users.</p>`;
-       }
-     }
-     ```
-     </TabItem>
-     <TabItem label="Kasper">
-     ```html
-     <!-- Protected.kasper -->
-     <template>
-       <require-auth>
-         <div @slot="fallback">Loading...</div>
-         <p>This content is only visible to authenticated users.</p>
-       </require-auth>
-     </template>
-
-     <script>
-     import { Component } from "kasper-js";
-
-     export class ProtectedPage extends Component {}
      </script>
      ```
      </TabItem>
@@ -765,6 +291,10 @@ This guide walks through adding OIDC authentication to your app. You'll need an 
 
 <Aside type="tip">
 Include `offline_access` in your scopes to receive a refresh token. Without it, the user's session ends when the access token expires.
+</Aside>
+
+<Aside>
+The `redirectUri` doesn't require a dedicated route. The auth provider detects the `code` and `state` query parameters on any page and completes the token exchange automatically. You can point it at your app's root or a specific `/callback` path — either works.
 </Aside>
 
 ## What happens under the hood

--- a/docs-web/src/content/docs/index.mdx
+++ b/docs-web/src/content/docs/index.mdx
@@ -27,7 +27,7 @@ The library follows a **functional core, imperative shell** architecture: the co
 <Tabs>
   <TabItem label="React">
   ```tsx
-  import { AuthProvider, RequireAuth } from "oidc-js-react";
+  import { AuthProvider, RequireAuth, useAuth } from "oidc-js-react";
 
   const config = {
     issuer: "https://auth.example.com",
@@ -38,7 +38,7 @@ The library follows a **functional core, imperative shell** architecture: the co
     return (
       <AuthProvider config={config}>
         <RequireAuth>
-          <MyApp />
+          <Dashboard />
         </RequireAuth>
       </AuthProvider>
     );
@@ -47,16 +47,27 @@ The library follows a **functional core, imperative shell** architecture: the co
   </TabItem>
   <TabItem label="Vue">
   ```ts
-  import { createApp } from "vue";
   import { oidcPlugin } from "oidc-js-vue";
 
-  const app = createApp(App);
   app.use(oidcPlugin, {
     config: {
       issuer: "https://auth.example.com",
       clientId: "my-app",
     },
   });
+  ```
+
+  ```vue
+  <!-- In any component -->
+  <script setup lang="ts">
+  import { RequireAuth } from "oidc-js-vue";
+  </script>
+
+  <template>
+    <RequireAuth>
+      <Dashboard />
+    </RequireAuth>
+  </template>
   ```
   </TabItem>
   <TabItem label="Svelte">
@@ -79,88 +90,6 @@ The library follows a **functional core, imperative shell** architecture: the co
       </RequireAuth>
     {/snippet}
   </AuthProvider>
-  ```
-  </TabItem>
-  <TabItem label="Angular">
-  ```ts
-  import { provideAuth, authGuard } from "oidc-js-angular";
-
-  const routes = [
-    { path: "protected", component: MyApp, canActivate: [authGuard] },
-  ];
-
-  bootstrapApplication(AppComponent, {
-    providers: [
-      provideRouter(routes),
-      provideAuth({
-        config: {
-          issuer: "https://auth.example.com",
-          clientId: "my-app",
-        },
-      }),
-    ],
-  });
-  ```
-  </TabItem>
-  <TabItem label="Solid">
-  ```tsx
-  import { AuthProvider, RequireAuth } from "oidc-js-solid";
-
-  const config = {
-    issuer: "https://auth.example.com",
-    clientId: "my-app",
-  };
-
-  function App() {
-    return (
-      <AuthProvider config={config}>
-        <RequireAuth>
-          <MyApp />
-        </RequireAuth>
-      </AuthProvider>
-    );
-  }
-  ```
-  </TabItem>
-  <TabItem label="Preact">
-  ```tsx
-  import { AuthProvider, RequireAuth } from "oidc-js-preact";
-
-  const config = {
-    issuer: "https://auth.example.com",
-    clientId: "my-app",
-  };
-
-  function App() {
-    return (
-      <AuthProvider config={config}>
-        <RequireAuth>
-          <MyApp />
-        </RequireAuth>
-      </AuthProvider>
-    );
-  }
-  ```
-  </TabItem>
-  <TabItem label="Lit">
-  ```ts
-  import { LitElement, html } from "lit";
-  import { AuthController, RequireAuthController } from "oidc-js-lit";
-
-  class AppRoot extends LitElement {
-    auth = new AuthController(this, {
-      config: {
-        issuer: "https://auth.example.com",
-        clientId: "my-app",
-      },
-    });
-    guard = new RequireAuthController(this, { auth: this.auth });
-
-    render() {
-      if (!this.guard.authorized) return html`<p>Loading...</p>`;
-      return html`<my-app></my-app>`;
-    }
-  }
   ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary
- **Landing page**: trimmed from 7 framework tabs to 3 (React, Vue, Svelte) with minimal config — keeps the "30 seconds" promise
- **Quickstart**: collapsed from 5 steps to 2 (install + add auth), flattened nested install tabs to a single line, merged provider setup / route protection / auth state into one cohesive example per framework, removed app bootstrap boilerplate and onLogin callbacks
- Added callouts for `offline_access` scope and redirect URI handling (no dedicated route required)
- Net reduction: 696 lines removed, 155 added

## Test plan
- [ ] Preview landing page at `/oidc-js/` — verify 3 tabs render correctly
- [ ] Preview quickstart at `/oidc-js/getting-started/quickstart/` — verify 2-step layout and all 8 framework tabs
- [ ] Verify callouts render after the steps
- [ ] Check code examples are syntactically correct and copy-pasteable

🤖 Generated with [Claude Code](https://claude.com/claude-code)