### PR TITLE
fix: surface OAuth2 error responses from token endpoint

### DIFF
--- a/packages/client/src/fetch.ts
+++ b/packages/client/src/fetch.ts
@@ -1,4 +1,4 @@
-import type { HttpRequest } from "oidc-js-core";
+import { OidcError, type HttpRequest } from "oidc-js-core";
 
 /**
  * Executes an HTTP request built by oidc-js-core and returns the parsed JSON response.
@@ -24,19 +24,21 @@ export async function executeFetch(
     try {
       errorBody = await response.json();
     } catch {
-      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      throw new OidcError("TOKEN_EXCHANGE_ERROR", `HTTP ${response.status}: ${response.statusText}`);
     }
+    // RFC 6749 §5.2: Error Response
     if (
       errorBody &&
       typeof errorBody === "object" &&
       "error" in errorBody
     ) {
-      const desc =
-        (errorBody as Record<string, unknown>).error_description ??
-        (errorBody as Record<string, unknown>).error;
-      throw new Error(`Token error: ${desc}`);
+      const record = errorBody as Record<string, unknown>;
+      const message = typeof record.error_description === "string"
+        ? `${record.error}: ${record.error_description}`
+        : String(record.error);
+      throw new OidcError("TOKEN_EXCHANGE_ERROR", message);
     }
-    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    throw new OidcError("TOKEN_EXCHANGE_ERROR", `HTTP ${response.status}: ${response.statusText}`);
   }
 
   return response.json();

--- a/packages/client/src/tests/fetch.test.ts
+++ b/packages/client/src/tests/fetch.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { executeFetch } from "../fetch.js";
-import type { HttpRequest } from "oidc-js-core";
+import { OidcError, type HttpRequest } from "oidc-js-core";
 
 beforeEach(() => {
   vi.restoreAllMocks();
@@ -67,19 +67,41 @@ describe("executeFetch", () => {
     expect(result).toEqual({ access_token: "at_123" });
   });
 
-  it("throws on non-OK response with OIDC error body", async () => {
+  it("RFC 6749 §5.2: throws OidcError with error code and description", async () => {
     vi.stubGlobal("fetch", mockFetch(
       { error: "invalid_grant", error_description: "Code expired" },
       400,
       "Bad Request",
     ));
 
-    await expect(
-      executeFetch({ url: "https://auth.example.com/token", method: "POST", headers: {} }),
-    ).rejects.toThrow("Token error: Code expired");
+    try {
+      await executeFetch({ url: "https://auth.example.com/token", method: "POST", headers: {} });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+      expect((e as OidcError).message).toBe("invalid_grant: Code expired");
+    }
   });
 
-  it("throws on non-OK response without JSON body", async () => {
+  it("RFC 6749 §5.2: throws OidcError with error code when no description", async () => {
+    vi.stubGlobal("fetch", mockFetch(
+      { error: "invalid_client" },
+      401,
+      "Unauthorized",
+    ));
+
+    try {
+      await executeFetch({ url: "https://auth.example.com/token", method: "POST", headers: {} });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+      expect((e as OidcError).message).toBe("invalid_client");
+    }
+  });
+
+  it("throws OidcError on non-OK response without JSON body", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
@@ -87,8 +109,13 @@ describe("executeFetch", () => {
       json: () => Promise.reject(new Error("not json")),
     }));
 
-    await expect(
-      executeFetch({ url: "https://auth.example.com/token", method: "POST", headers: {} }),
-    ).rejects.toThrow("HTTP 500: Internal Server Error");
+    try {
+      await executeFetch({ url: "https://auth.example.com/token", method: "POST", headers: {} });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+      expect((e as OidcError).message).toBe("HTTP 500: Internal Server Error");
+    }
   });
 });

--- a/packages/core/src/tests/token.test.ts
+++ b/packages/core/src/tests/token.test.ts
@@ -169,6 +169,32 @@ describe("parseTokenResponse", () => {
     expect(result.access_token).toBe("at");
   });
 
+  // RFC 6749 §5.2: Error Response
+  it("RFC 6749 §5.2: throws TOKEN_EXCHANGE_ERROR with error code from IdP", () => {
+    try {
+      parseTokenResponse({ error: "invalid_grant" });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+      expect((e as OidcError).message).toBe("invalid_grant");
+    }
+  });
+
+  it("RFC 6749 §5.2: includes error_description when present", () => {
+    try {
+      parseTokenResponse({
+        error: "invalid_grant",
+        error_description: "Refresh token has been revoked",
+      });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(OidcError);
+      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+      expect((e as OidcError).message).toBe("invalid_grant: Refresh token has been revoked");
+    }
+  });
+
   it("throws TOKEN_EXCHANGE_ERROR on missing access_token", () => {
     try {
       parseTokenResponse({ token_type: "Bearer" });

--- a/packages/core/src/token.ts
+++ b/packages/core/src/token.ts
@@ -95,6 +95,14 @@ export function parseTokenResponse(data: unknown, expectedNonce?: string): Token
 
   const response = data as Record<string, unknown>;
 
+  // RFC 6749 §5.2: Error Response — check before access_token so callers get the IdP's error code
+  if (typeof response.error === "string") {
+    const description = typeof response.error_description === "string"
+      ? `${response.error}: ${response.error_description}`
+      : response.error;
+    throw new OidcError("TOKEN_EXCHANGE_ERROR", description);
+  }
+
   if (typeof response.access_token !== "string") {
     throw new OidcError("TOKEN_EXCHANGE_ERROR", "Missing access_token in token response");
   }


### PR DESCRIPTION
## Summary
- `parseTokenResponse` now checks for the `error` field (RFC 6749 §5.2) before checking for `access_token`
- Surfaces the IdP's actual error code and description (e.g. `invalid_grant: Refresh token has been revoked`) instead of a generic `Missing access_token` message
- Follows the same pattern as `parseCallbackUrl` which already handles authorization error responses

## Test plan
- [x] New test: throws `TOKEN_EXCHANGE_ERROR` with error code from IdP
- [x] New test: includes `error_description` when present
- [x] Existing tests pass (101/101)

🤖 Generated with [Claude Code](https://claude.com/claude-code)