### PR TITLE
fix: centralize error codes and add USERINFO_ERROR, INTROSPECTION_ERROR

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,10 +238,12 @@ try {
 | `NONCE_MISMATCH` | `parseTokenResponse` | Nonce in ID token doesn't match |
 | `MISSING_AUTH_CODE` | `parseCallbackUrl` | No authorization code in callback URL |
 | `INVALID_JWT` | `decodeJwtPayload` | Malformed JWT |
-| `TOKEN_EXCHANGE_ERROR` | `parseTokenResponse` | Invalid token response |
+| `TOKEN_EXCHANGE_ERROR` | `parseTokenResponse`, `executeFetch` | Token endpoint error (includes IdP error code when available) |
 | `AUTHORIZATION_ERROR` | `parseCallbackUrl` | Authorization server returned an error |
 | `MISSING_REDIRECT_URI` | `buildAuthUrl` | `redirectUri` not set in config |
 | `MISSING_CLIENT_SECRET` | `buildIntrospectRequest` | `clientSecret` required but not set |
+| `USERINFO_ERROR` | `parseUserinfoResponse` | Malformed userinfo response or missing `sub` claim |
+| `INTROSPECTION_ERROR` | `parseIntrospectResponse` | Malformed introspection response or missing `active` field |
 
 ## RFC Compliance
 

--- a/packages/client/src/fetch.ts
+++ b/packages/client/src/fetch.ts
@@ -1,4 +1,4 @@
-import { OidcError, type HttpRequest } from "oidc-js-core";
+import { OidcErrors, type HttpRequest } from "oidc-js-core";
 
 /**
  * Executes an HTTP request built by oidc-js-core and returns the parsed JSON response.
@@ -24,7 +24,7 @@ export async function executeFetch(
     try {
       errorBody = await response.json();
     } catch {
-      throw new OidcError("TOKEN_EXCHANGE_ERROR", `HTTP ${response.status}: ${response.statusText}`);
+      throw OidcErrors.tokenExchangeError(`HTTP ${response.status}: ${response.statusText}`);
     }
     // RFC 6749 §5.2: Error Response
     if (
@@ -36,9 +36,9 @@ export async function executeFetch(
       const message = typeof record.error_description === "string"
         ? `${record.error}: ${record.error_description}`
         : String(record.error);
-      throw new OidcError("TOKEN_EXCHANGE_ERROR", message);
+      throw OidcErrors.tokenExchangeError(message);
     }
-    throw new OidcError("TOKEN_EXCHANGE_ERROR", `HTTP ${response.status}: ${response.statusText}`);
+    throw OidcErrors.tokenExchangeError(`HTTP ${response.status}: ${response.statusText}`);
   }
 
   return response.json();

--- a/packages/core/src/authorize.ts
+++ b/packages/core/src/authorize.ts
@@ -1,5 +1,5 @@
 import type { OidcConfig, OidcDiscovery } from "./types.js";
-import { OidcError } from "./errors.js";
+import { OidcErrors } from "./errors.js";
 
 /**
  * Builds the full authorization endpoint URL with all required query parameters.
@@ -32,7 +32,7 @@ export function buildAuthUrl(
   extraParams?: Record<string, string>,
 ): string {
   if (!config.redirectUri) {
-    throw new OidcError("MISSING_REDIRECT_URI", "redirectUri is required for authorization requests");
+    throw OidcErrors.missingRedirectUri();
   }
 
   // RFC 6749 §4.1.1: required parameters
@@ -76,18 +76,18 @@ export function parseCallbackUrl(url: string, expectedState: string): { code: st
   // RFC 6749 §4.1.2.1: Error Response
   if (error) {
     const description = parsed.searchParams.get("error_description") ?? error;
-    throw new OidcError("AUTHORIZATION_ERROR", description);
+    throw OidcErrors.authorizationError(description);
   }
 
   const code = parsed.searchParams.get("code");
   if (!code) {
-    throw new OidcError("MISSING_AUTH_CODE", "No authorization code in callback URL");
+    throw OidcErrors.missingAuthCode();
   }
 
   const returnedState = parsed.searchParams.get("state");
   // RFC 6749 §10.12: the client MUST verify that the state matches
   if (returnedState !== expectedState) {
-    throw new OidcError("STATE_MISMATCH", "State parameter does not match — possible CSRF attack");
+    throw OidcErrors.stateMismatch();
   }
 
   return { code, state: returnedState };

--- a/packages/core/src/crypto.ts
+++ b/packages/core/src/crypto.ts
@@ -1,4 +1,4 @@
-import { OidcError } from "./errors.js";
+import { OidcErrors } from "./errors.js";
 
 // RFC 7636 §4.1: unreserved characters for code_verifier
 const UNRESERVED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
@@ -34,7 +34,7 @@ export function base64UrlDecode(str: string): Uint8Array {
     }
     return bytes;
   } catch {
-    throw new OidcError("INVALID_JWT", "Invalid base64url input");
+    throw OidcErrors.invalidBase64url();
   }
 }
 

--- a/packages/core/src/discovery.ts
+++ b/packages/core/src/discovery.ts
@@ -1,5 +1,5 @@
 import type { OidcDiscovery } from "./types.js";
-import { OidcError } from "./errors.js";
+import { OidcErrors } from "./errors.js";
 
 /**
  * Constructs the well-known OpenID Provider Configuration URL for the given issuer.
@@ -46,20 +46,20 @@ const REQUIRED_ARRAY_FIELDS: (keyof OidcDiscovery)[] = [
 // OIDC Discovery §4.3: OpenID Provider Configuration Response
 export function parseDiscoveryResponse(data: unknown, expectedIssuer: string): OidcDiscovery {
   if (!data || typeof data !== "object") {
-    throw new OidcError("DISCOVERY_INVALID", "Discovery response must be a JSON object");
+    throw OidcErrors.discoveryNotObject();
   }
 
   const doc = data as Record<string, unknown>;
 
   for (const field of REQUIRED_STRING_FIELDS) {
     if (typeof doc[field] !== "string") {
-      throw new OidcError("DISCOVERY_INVALID", `Missing or invalid required field: ${field}`);
+      throw OidcErrors.discoveryMissingField(field);
     }
   }
 
   for (const field of REQUIRED_ARRAY_FIELDS) {
     if (!Array.isArray(doc[field])) {
-      throw new OidcError("DISCOVERY_INVALID", `Missing or invalid required field: ${field}`);
+      throw OidcErrors.discoveryMissingField(field);
     }
   }
 
@@ -67,10 +67,7 @@ export function parseDiscoveryResponse(data: unknown, expectedIssuer: string): O
   const normalizedExpected = expectedIssuer.replace(/\/+$/, "");
   const normalizedActual = (doc.issuer as string).replace(/\/+$/, "");
   if (normalizedActual !== normalizedExpected) {
-    throw new OidcError(
-      "DISCOVERY_ISSUER_MISMATCH",
-      `Expected issuer ${normalizedExpected}, got ${normalizedActual}`,
-    );
+    throw OidcErrors.discoveryIssuerMismatch(normalizedExpected, normalizedActual);
   }
 
   return data as OidcDiscovery;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -2,7 +2,7 @@
  * Union of all typed error codes thrown by oidc-js-core.
  *
  * Each code maps to a specific validation or protocol failure defined in
- * RFC 6749, RFC 7636, or OpenID Connect Core 1.0.
+ * RFC 6749, RFC 7636, RFC 7662, or OpenID Connect Core 1.0.
  */
 export type OidcErrorCode =
   | "DISCOVERY_INVALID"
@@ -14,7 +14,9 @@ export type OidcErrorCode =
   | "TOKEN_EXCHANGE_ERROR"
   | "AUTHORIZATION_ERROR"
   | "MISSING_REDIRECT_URI"
-  | "MISSING_CLIENT_SECRET";
+  | "MISSING_CLIENT_SECRET"
+  | "USERINFO_ERROR"
+  | "INTROSPECTION_ERROR";
 
 /**
  * Structured error thrown by all oidc-js-core functions instead of generic `Error`.
@@ -31,3 +33,44 @@ export class OidcError extends Error {
     this.name = "OidcError";
   }
 }
+
+export const OidcErrors = {
+  discoveryNotObject: () =>
+    new OidcError("DISCOVERY_INVALID", "Discovery response must be a JSON object"),
+  discoveryMissingField: (field: string) =>
+    new OidcError("DISCOVERY_INVALID", `Missing or invalid required field: ${field}`),
+  discoveryIssuerMismatch: (expected: string, actual: string) =>
+    new OidcError("DISCOVERY_ISSUER_MISMATCH", `Expected issuer "${expected}", got "${actual}"`),
+  missingRedirectUri: () =>
+    new OidcError("MISSING_REDIRECT_URI", "redirectUri is required for authorization requests"),
+  authorizationError: (description: string) =>
+    new OidcError("AUTHORIZATION_ERROR", description),
+  missingAuthCode: () =>
+    new OidcError("MISSING_AUTH_CODE", "No authorization code in callback URL"),
+  stateMismatch: () =>
+    new OidcError("STATE_MISMATCH", "State parameter does not match — possible CSRF attack"),
+  missingClientSecret: () =>
+    new OidcError("MISSING_CLIENT_SECRET", "clientSecret is required for token introspection"),
+  tokenResponseNotObject: () =>
+    new OidcError("TOKEN_EXCHANGE_ERROR", "Token response must be a JSON object"),
+  tokenExchangeError: (description: string) =>
+    new OidcError("TOKEN_EXCHANGE_ERROR", description),
+  missingAccessToken: () =>
+    new OidcError("TOKEN_EXCHANGE_ERROR", "Missing access_token in token response"),
+  nonceMismatch: () =>
+    new OidcError("NONCE_MISMATCH", "Nonce in ID token does not match the expected value"),
+  invalidJwtParts: () =>
+    new OidcError("INVALID_JWT", "JWT must have 3 parts separated by dots"),
+  invalidJwtDecode: () =>
+    new OidcError("INVALID_JWT", "Failed to decode JWT payload"),
+  invalidBase64url: () =>
+    new OidcError("INVALID_JWT", "Invalid base64url input"),
+  userinfoNotObject: () =>
+    new OidcError("USERINFO_ERROR", "UserInfo response must be a JSON object"),
+  userinfoMissingSub: () =>
+    new OidcError("USERINFO_ERROR", "Missing or invalid 'sub' claim in UserInfo response"),
+  introspectionNotObject: () =>
+    new OidcError("INTROSPECTION_ERROR", "Introspection response must be a JSON object"),
+  introspectionMissingActive: () =>
+    new OidcError("INTROSPECTION_ERROR", "Missing or invalid 'active' field in introspection response"),
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { OidcError, type OidcErrorCode } from "./errors.js";
+export { OidcError, OidcErrors, type OidcErrorCode } from "./errors.js";
 
 export {
   generateRandom,

--- a/packages/core/src/introspect.ts
+++ b/packages/core/src/introspect.ts
@@ -1,5 +1,5 @@
 import type { OidcConfig, OidcDiscovery, HttpRequest, IntrospectionResponse } from "./types.js";
-import { OidcError } from "./errors.js";
+import { OidcErrors } from "./errors.js";
 import { buildClientAuthHeaders } from "./auth.js";
 
 /**
@@ -25,7 +25,7 @@ export function buildIntrospectRequest(
   }
 
   if (!config.clientSecret) {
-    throw new OidcError("MISSING_CLIENT_SECRET", "clientSecret is required for token introspection");
+    throw OidcErrors.missingClientSecret();
   }
 
   const body = new URLSearchParams({ token });
@@ -46,20 +46,20 @@ export function buildIntrospectRequest(
  *
  * @param data - The parsed JSON body returned from the introspection endpoint.
  * @returns The validated {@link IntrospectionResponse}.
- * @throws {@link OidcError} with code `TOKEN_EXCHANGE_ERROR` if the response is not an object or `active` is missing.
+ * @throws {@link OidcError} with code `INTROSPECTION_ERROR` if the response is not an object or `active` is missing.
  *
  * @see RFC 7662 §2.2 -- Introspection Response
  */
 // RFC 7662 §2.2: Introspection Response
 export function parseIntrospectResponse(data: unknown): IntrospectionResponse {
   if (!data || typeof data !== "object") {
-    throw new OidcError("TOKEN_EXCHANGE_ERROR", "Introspection response must be a JSON object");
+    throw OidcErrors.introspectionNotObject();
   }
 
   const response = data as Record<string, unknown>;
 
   if (typeof response.active !== "boolean") {
-    throw new OidcError("TOKEN_EXCHANGE_ERROR", "Missing or invalid 'active' field in introspection response");
+    throw OidcErrors.introspectionMissingActive();
   }
 
   return data as IntrospectionResponse;

--- a/packages/core/src/jwt.ts
+++ b/packages/core/src/jwt.ts
@@ -1,5 +1,5 @@
 import type { OidcUser } from "./types.js";
-import { OidcError } from "./errors.js";
+import { OidcErrors } from "./errors.js";
 
 /**
  * Decodes the payload of a JWT without verifying its signature (RFC 7519 §7.2).
@@ -12,7 +12,7 @@ import { OidcError } from "./errors.js";
 export function decodeJwtPayload(token: string): Record<string, unknown> {
   const parts = token.split(".");
   if (parts.length !== 3) {
-    throw new OidcError("INVALID_JWT", "JWT must have 3 parts separated by dots");
+    throw OidcErrors.invalidJwtParts();
   }
 
   try {
@@ -20,7 +20,7 @@ export function decodeJwtPayload(token: string): Record<string, unknown> {
     const padded = payload + "=".repeat((4 - (payload.length % 4)) % 4);
     return JSON.parse(atob(padded));
   } catch {
-    throw new OidcError("INVALID_JWT", "Failed to decode JWT payload");
+    throw OidcErrors.invalidJwtDecode();
   }
 }
 

--- a/packages/core/src/tests/introspect.test.ts
+++ b/packages/core/src/tests/introspect.test.ts
@@ -97,29 +97,29 @@ describe("parseIntrospectResponse", () => {
     expect(result.active).toBe(false);
   });
 
-  it("throws TOKEN_EXCHANGE_ERROR on non-object input", () => {
+  it("throws INTROSPECTION_ERROR on non-object input", () => {
     expect(() => parseIntrospectResponse(null)).toThrow(OidcError);
     expect(() => parseIntrospectResponse("string")).toThrow(OidcError);
     expect(() => parseIntrospectResponse(42)).toThrow(OidcError);
   });
 
-  it("throws TOKEN_EXCHANGE_ERROR when active field is missing", () => {
+  it("throws INTROSPECTION_ERROR when active field is missing", () => {
     try {
       parseIntrospectResponse({ scope: "openid" });
       expect.fail("should have thrown");
     } catch (e) {
       expect(e).toBeInstanceOf(OidcError);
-      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+      expect((e as OidcError).code).toBe("INTROSPECTION_ERROR");
     }
   });
 
-  it("throws TOKEN_EXCHANGE_ERROR when active field is not boolean", () => {
+  it("throws INTROSPECTION_ERROR when active field is not boolean", () => {
     try {
       parseIntrospectResponse({ active: "true" });
       expect.fail("should have thrown");
     } catch (e) {
       expect(e).toBeInstanceOf(OidcError);
-      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+      expect((e as OidcError).code).toBe("INTROSPECTION_ERROR");
     }
   });
 });

--- a/packages/core/src/tests/userinfo.test.ts
+++ b/packages/core/src/tests/userinfo.test.ts
@@ -68,30 +68,30 @@ describe("parseUserinfoResponse", () => {
     expect(user.groups).toEqual(["admin", "users"]);
   });
 
-  it("throws TOKEN_EXCHANGE_ERROR on non-object input", () => {
+  it("throws USERINFO_ERROR on non-object input", () => {
     expect(() => parseUserinfoResponse(null)).toThrow(OidcError);
     expect(() => parseUserinfoResponse("string")).toThrow(OidcError);
     expect(() => parseUserinfoResponse(42)).toThrow(OidcError);
   });
 
   // OIDC Core §5.3.2: sub claim is REQUIRED
-  it("OIDC Core §5.3.2: throws TOKEN_EXCHANGE_ERROR when sub claim is missing", () => {
+  it("OIDC Core §5.3.2: throws USERINFO_ERROR when sub claim is missing", () => {
     try {
       parseUserinfoResponse({ email: "user@example.com" });
       expect.fail("should have thrown");
     } catch (e) {
       expect(e).toBeInstanceOf(OidcError);
-      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+      expect((e as OidcError).code).toBe("USERINFO_ERROR");
     }
   });
 
-  it("throws TOKEN_EXCHANGE_ERROR when sub claim is not a string", () => {
+  it("throws USERINFO_ERROR when sub claim is not a string", () => {
     try {
       parseUserinfoResponse({ sub: 123, email: "user@example.com" });
       expect.fail("should have thrown");
     } catch (e) {
       expect(e).toBeInstanceOf(OidcError);
-      expect((e as OidcError).code).toBe("TOKEN_EXCHANGE_ERROR");
+      expect((e as OidcError).code).toBe("USERINFO_ERROR");
     }
   });
 });

--- a/packages/core/src/token.ts
+++ b/packages/core/src/token.ts
@@ -1,5 +1,5 @@
 import type { OidcConfig, OidcDiscovery, HttpRequest, TokenSet } from "./types.js";
-import { OidcError } from "./errors.js";
+import { OidcErrors } from "./errors.js";
 import { decodeJwtPayload } from "./jwt.js";
 import { buildClientAuthHeaders } from "./auth.js";
 import { computeExpiresAt } from "./token-utils.js";
@@ -90,7 +90,7 @@ export function buildRefreshRequest(
 // OIDC Core §3.1.3.7: nonce in ID token MUST match the nonce sent in the authorization request
 export function parseTokenResponse(data: unknown, expectedNonce?: string): TokenSet {
   if (!data || typeof data !== "object") {
-    throw new OidcError("TOKEN_EXCHANGE_ERROR", "Token response must be a JSON object");
+    throw OidcErrors.tokenResponseNotObject();
   }
 
   const response = data as Record<string, unknown>;
@@ -100,18 +100,18 @@ export function parseTokenResponse(data: unknown, expectedNonce?: string): Token
     const description = typeof response.error_description === "string"
       ? `${response.error}: ${response.error_description}`
       : response.error;
-    throw new OidcError("TOKEN_EXCHANGE_ERROR", description);
+    throw OidcErrors.tokenExchangeError(description);
   }
 
   if (typeof response.access_token !== "string") {
-    throw new OidcError("TOKEN_EXCHANGE_ERROR", "Missing access_token in token response");
+    throw OidcErrors.missingAccessToken();
   }
 
   // OIDC Core §3.1.3.7: if a nonce was sent, it MUST be present and match in the ID token
   if (expectedNonce && typeof response.id_token === "string") {
     const claims = decodeJwtPayload(response.id_token);
     if (claims.nonce !== expectedNonce) {
-      throw new OidcError("NONCE_MISMATCH", "Nonce in ID token does not match the expected value");
+      throw OidcErrors.nonceMismatch();
     }
   }
 

--- a/packages/core/src/userinfo.ts
+++ b/packages/core/src/userinfo.ts
@@ -1,5 +1,5 @@
 import type { OidcDiscovery, HttpRequest, OidcUser } from "./types.js";
-import { OidcError } from "./errors.js";
+import { OidcErrors } from "./errors.js";
 
 /**
  * Builds an HTTP request to the UserInfo endpoint using a Bearer access token.
@@ -28,21 +28,21 @@ export function buildUserinfoRequest(discovery: OidcDiscovery, accessToken: stri
  *
  * @param data - The parsed JSON body returned from the UserInfo endpoint.
  * @returns The validated {@link OidcUser} object.
- * @throws {@link OidcError} with code `TOKEN_EXCHANGE_ERROR` if the response is not an object or `sub` is missing.
+ * @throws {@link OidcError} with code `USERINFO_ERROR` if the response is not an object or `sub` is missing.
  *
  * @see OpenID Connect Core 1.0 §5.3.2 -- UserInfo Response
  */
 // OIDC Core §5.3.2: UserInfo Response
 export function parseUserinfoResponse(data: unknown): OidcUser {
   if (!data || typeof data !== "object") {
-    throw new OidcError("TOKEN_EXCHANGE_ERROR", "UserInfo response must be a JSON object");
+    throw OidcErrors.userinfoNotObject();
   }
 
   const response = data as Record<string, unknown>;
 
   // OIDC Core §5.3.2: sub claim is REQUIRED
   if (typeof response.sub !== "string") {
-    throw new OidcError("TOKEN_EXCHANGE_ERROR", "Missing or invalid 'sub' claim in UserInfo response");
+    throw OidcErrors.userinfoMissingSub();
   }
 
   return data as OidcUser;


### PR DESCRIPTION
## Summary

- Adds `USERINFO_ERROR` and `INTROSPECTION_ERROR` error codes — previously both used `TOKEN_EXCHANGE_ERROR`, making it impossible to distinguish which endpoint failed
- Centralizes all error construction in an `OidcErrors` factory object in `errors.ts` — replaces inline `new OidcError(code, message)` across 8 source files
- Updates test assertions for the new error codes
- Updates README error table with new codes

## Test plan

- [x] All 101 core tests pass
- [x] All 23 client tests pass
- [x] Userinfo tests assert `USERINFO_ERROR` code
- [x] Introspection tests assert `INTROSPECTION_ERROR` code
- [x] No changes to public API beyond new exports (`OidcErrors`, new error codes)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)