### PR TITLE
chore: bump all packages to 1.0.8

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-angular",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Simple OIDC authentication for Angular. Signals, DI, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Simple OIDC authentication for JavaScript. Drop-in client with login, logout, token refresh, and zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-core",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Zero-dependency OIDC/OAuth 2.0 functions for JavaScript. Pure, functional, works everywhere.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kasper/package.json
+++ b/packages/kasper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-kasper",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Simple OIDC authentication for Kasper.js. Signals, components, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-lit",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Simple OIDC authentication for Lit. Reactive controllers for login, logout, and token refresh with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-preact",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Simple OIDC authentication for Preact. Hooks, provider, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-react",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Simple OIDC authentication for React. Provider, hooks, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-solid",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Simple OIDC authentication for SolidJS. Signals, context, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-svelte",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Simple OIDC authentication for Svelte 5. Context, runes, and auth guards with zero dependencies.",
   "type": "module",
   "svelte": "./dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-vue",
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "Simple OIDC authentication for Vue. Plugin, composables, and navigation guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Bumps all 10 publishable packages from `1.0.6` to `1.0.8`
- Includes recent changes: error codes refactor (#63), token error response fix (#61), security docs (#60), quickstart cleanup (#59)

## Packages

| Package | Version |
|---------|---------|
| oidc-js-core | 1.0.8 |
| oidc-js | 1.0.8 |
| oidc-js-react | 1.0.8 |
| oidc-js-vue | 1.0.8 |
| oidc-js-svelte | 1.0.8 |
| oidc-js-angular | 1.0.8 |
| oidc-js-solid | 1.0.8 |
| oidc-js-preact | 1.0.8 |
| oidc-js-lit | 1.0.8 |
| oidc-js-kasper | 1.0.8 |

## Test plan

- [x] Version-only change, no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)