### PR TITLE
chore: scope build script to packages only

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "description": "Zero-dependency OIDC client libraries",
   "scripts": {
-    "build": "pnpm -r build",
+    "build": "pnpm --filter './packages/*' -r build",
     "test": "pnpm -r test",
     "lint": "eslint . && pnpm -r lint",
     "test:e2e": "pnpm --filter e2e-tests test",


### PR DESCRIPTION
## Summary

- Changes `pnpm build` from `pnpm -r build` to `pnpm --filter './packages/*' -r build`
- Prevents building e2e apps and docs-web during `pnpm build`
- Docs have their own CI workflow (`docs.yml`) with a separate `--filter oidc-js-docs` command

## Test plan

- [x] Script change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)