### PR TITLE
feat: return values from refresh/fetchProfile, expose client

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-angular",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Simple OIDC authentication for Angular. Signals, DI, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/angular/src/auth.service.ts
+++ b/packages/angular/src/auth.service.ts
@@ -127,8 +127,8 @@ export class AuthService {
    *
    * @throws Error if no refresh token is available.
    */
-  async refresh(): Promise<void> {
-    await this.client.refresh();
+  async refresh() {
+    return this.client.refresh();
   }
 
   /**
@@ -136,7 +136,7 @@ export class AuthService {
    *
    * @throws Error if no access token is available.
    */
-  async fetchProfile(): Promise<void> {
-    await this.client.fetchProfile();
+  async fetchProfile() {
+    return this.client.fetchProfile();
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Simple OIDC authentication for JavaScript. Drop-in client with login, logout, token refresh, and zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -51,7 +51,7 @@ export class OidcClient {
   private discovery: OidcDiscovery | null = null;
   private subscribers = new Set<Subscriber>();
   private abortController: AbortController | null = null;
-  private refreshPromise: Promise<void> | null = null;
+  private refreshPromise: Promise<AuthTokens> | null = null;
 
   private _state: AuthState = {
     user: null,
@@ -243,7 +243,7 @@ export class OidcClient {
    *
    * @throws Error if no refresh token is available or discovery has not been fetched.
    */
-  async refresh(): Promise<void> {
+  async refresh(): Promise<AuthTokens> {
     if (this.refreshPromise) {
       return this.refreshPromise;
     }
@@ -255,7 +255,7 @@ export class OidcClient {
     return this.refreshPromise;
   }
 
-  private async refreshInternal(): Promise<void> {
+  private async refreshInternal(): Promise<AuthTokens> {
     const refreshToken = this._state.tokens.refresh;
 
     if (!this.discovery || !refreshToken) {
@@ -289,6 +289,8 @@ export class OidcClient {
       isAuthenticated: true,
       error: null,
     });
+
+    return newTokens;
   }
 
   /**
@@ -298,7 +300,7 @@ export class OidcClient {
    *
    * @throws Error if no access token is available or discovery has not been fetched.
    */
-  async fetchProfile(): Promise<void> {
+  async fetchProfile(): Promise<OidcUser | null> {
     if (!this.discovery || !this._state.tokens.access) {
       throw new Error("No access token available");
     }
@@ -307,6 +309,7 @@ export class OidcClient {
     if (this._state.user) {
       this.setState({ user: { ...this._state.user, profile } });
     }
+    return profile;
   }
 
   /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-core",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Zero-dependency OIDC/OAuth 2.0 functions for JavaScript. Pure, functional, works everywhere.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kasper/package.json
+++ b/packages/kasper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-kasper",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Simple OIDC authentication for Kasper.js. Signals, components, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kasper/src/types.ts
+++ b/packages/kasper/src/types.ts
@@ -1,6 +1,7 @@
 import type { Signal } from "kasper-js";
 import type { OidcConfig } from "oidc-js-core";
 import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcUser } from "oidc-js-core";
 
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 export type { Signal } from "kasper-js";
@@ -12,9 +13,9 @@ export interface AuthActions {
   /** Logs the user out and redirects to the post-logout URI. */
   logout: () => void;
   /** Refreshes the access token using the refresh token. */
-  refresh: () => Promise<void>;
+  refresh: () => Promise<AuthTokens>;
   /** Fetches the user's profile from the userinfo endpoint. */
-  fetchProfile: () => Promise<void>;
+  fetchProfile: () => Promise<OidcUser | null>;
 }
 
 /** Value returned by {@link useAuth}. All state properties are Kasper signals. */

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-lit",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Simple OIDC authentication for Lit. Reactive controllers for login, logout, and token refresh with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/lit/src/auth-controller.ts
+++ b/packages/lit/src/auth-controller.ts
@@ -148,8 +148,9 @@ export class AuthController implements ReactiveController {
    *
    * @throws Error if no refresh token is available or discovery has not been fetched.
    */
-  async refresh(): Promise<void> {
-    await this.client?.refresh();
+  async refresh() {
+    const result = await this.client?.refresh();
+    return result ?? { access: null, id: null, refresh: null, expiresAt: null };
   }
 
   /**
@@ -157,7 +158,7 @@ export class AuthController implements ReactiveController {
    *
    * @throws Error if no access token is available or discovery has not been fetched.
    */
-  async fetchProfile(): Promise<void> {
-    await this.client?.fetchProfile();
+  async fetchProfile() {
+    return (await this.client?.fetchProfile()) ?? null;
   }
 }

--- a/packages/lit/src/types.ts
+++ b/packages/lit/src/types.ts
@@ -2,7 +2,8 @@ import type { OidcConfig } from "oidc-js-core";
 
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
-import type { LoginOptions } from "oidc-js";
+import type { AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcUser } from "oidc-js-core";
 
 /**
  * Actions available on the {@link AuthController} for triggering authentication operations.
@@ -13,9 +14,9 @@ export interface AuthActions {
   /** Logs the user out and redirects to the OP's end-session endpoint. */
   logout: () => void;
   /** Uses the stored refresh token to obtain new tokens. */
-  refresh: () => Promise<void>;
+  refresh: () => Promise<AuthTokens>;
   /** Fetches the user's profile from the userinfo endpoint. */
-  fetchProfile: () => Promise<void>;
+  fetchProfile: () => Promise<OidcUser | null>;
 }
 
 /**

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-preact",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Simple OIDC authentication for Preact. Hooks, provider, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/preact/src/context.tsx
+++ b/packages/preact/src/context.tsx
@@ -88,11 +88,12 @@ export function AuthProvider({
   }, []);
 
   const refresh = useCallback(async () => {
-    await clientRef.current?.refresh();
+    const result = await clientRef.current?.refresh();
+    return result ?? { access: null, id: null, refresh: null, expiresAt: null };
   }, []);
 
   const doFetchProfile = useCallback(async () => {
-    await clientRef.current?.fetchProfile();
+    return (await clientRef.current?.fetchProfile()) ?? null;
   }, []);
 
   const actions = useMemo(

--- a/packages/preact/src/types.ts
+++ b/packages/preact/src/types.ts
@@ -3,6 +3,7 @@ import type { OidcConfig } from "oidc-js-core";
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
 import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcUser } from "oidc-js-core";
 
 /** Actions available for controlling the authentication lifecycle. */
 export interface AuthActions {
@@ -11,9 +12,9 @@ export interface AuthActions {
   /** Logs the user out and optionally redirects to the OP's end-session endpoint. */
   logout: () => void;
   /** Refreshes the access token using the stored refresh token. */
-  refresh: () => Promise<void>;
+  refresh: () => Promise<AuthTokens>;
   /** Fetches the user's profile from the userinfo endpoint. */
-  fetchProfile: () => Promise<void>;
+  fetchProfile: () => Promise<OidcUser | null>;
 }
 
 /** The value provided by {@link AuthProvider} and consumed by {@link useAuth}. */

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-react",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Simple OIDC authentication for React. Provider, hooks, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -80,11 +80,12 @@ export function AuthProvider({
   }, []);
 
   const refresh = useCallback(async () => {
-    await clientRef.current?.refresh();
+    const result = await clientRef.current?.refresh();
+    return result ?? { access: null, id: null, refresh: null, expiresAt: null };
   }, []);
 
   const doFetchProfile = useCallback(async () => {
-    await clientRef.current?.fetchProfile();
+    return (await clientRef.current?.fetchProfile()) ?? null;
   }, []);
 
   const actions = useMemo(
@@ -93,7 +94,7 @@ export function AuthProvider({
   );
 
   const value: AuthContextValue = useMemo(
-    () => ({ config, ...state, actions }),
+    () => ({ config, client: clientRef.current!, ...state, actions }),
     [config, state, actions],
   );
 

--- a/packages/react/src/tests/auth-required.test.tsx
+++ b/packages/react/src/tests/auth-required.test.tsx
@@ -25,6 +25,7 @@ function makeActions(overrides: Partial<AuthContextValue["actions"]> = {}) {
 function makeAuth(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
   return {
     config: { issuer: "https://auth.example.com", clientId: "app" },
+    client: {} as AuthContextValue["client"],
     user: null,
     isAuthenticated: false,
     isLoading: false,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -2,17 +2,19 @@ import type { OidcConfig } from "oidc-js-core";
 
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
-import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcClient, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcUser } from "oidc-js-core";
 
 export interface AuthActions {
   login: (options?: LoginOptions) => void;
   logout: () => void;
-  refresh: () => Promise<void>;
-  fetchProfile: () => Promise<void>;
+  refresh: () => Promise<AuthTokens>;
+  fetchProfile: () => Promise<OidcUser | null>;
 }
 
 export interface AuthContextValue {
   config: OidcConfig;
+  client: OidcClient;
   user: AuthUser | null;
   isAuthenticated: boolean;
   isLoading: boolean;

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-solid",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Simple OIDC authentication for SolidJS. Signals, context, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/solid/src/context.tsx
+++ b/packages/solid/src/context.tsx
@@ -90,11 +90,12 @@ export const AuthProvider: ParentComponent<AuthProviderProps> = (props) => {
   };
 
   const refresh = async () => {
-    await client?.refresh();
+    const result = await client?.refresh();
+    return result ?? { access: null, id: null, refresh: null, expiresAt: null };
   };
 
   const doFetchProfile = async () => {
-    await client?.fetchProfile();
+    return (await client?.fetchProfile()) ?? null;
   };
 
   const actions = { login, logout, refresh, fetchProfile: doFetchProfile };

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -3,6 +3,7 @@ import type { OidcConfig } from "oidc-js-core";
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
 import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcUser } from "oidc-js-core";
 
 /**
  * Actions available for controlling authentication flow.
@@ -15,9 +16,9 @@ export interface AuthActions {
   /** Logs out the current user and clears auth state. */
   logout: () => void;
   /** Refreshes the access token using the stored refresh token. */
-  refresh: () => Promise<void>;
+  refresh: () => Promise<AuthTokens>;
   /** Fetches the user's profile from the userinfo endpoint. */
-  fetchProfile: () => Promise<void>;
+  fetchProfile: () => Promise<OidcUser | null>;
 }
 
 /**

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-svelte",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Simple OIDC authentication for Svelte 5. Context, runes, and auth guards with zero dependencies.",
   "type": "module",
   "svelte": "./dist/index.js",

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -3,6 +3,7 @@ import type { OidcConfig } from "oidc-js-core";
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
 import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcUser } from "oidc-js-core";
 
 /** Actions available to interact with the OIDC authentication flow. */
 export interface AuthActions {
@@ -11,9 +12,9 @@ export interface AuthActions {
   /** Logs the user out and redirects to the end-session endpoint. */
   logout: () => void;
   /** Refreshes the access token using the stored refresh token. */
-  refresh: () => Promise<void>;
+  refresh: () => Promise<AuthTokens>;
   /** Fetches the user's profile from the userinfo endpoint. */
-  fetchProfile: () => Promise<void>;
+  fetchProfile: () => Promise<OidcUser | null>;
 }
 
 /** Reactive authentication context value provided by {@link AuthProvider}. */

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-vue",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "Simple OIDC authentication for Vue. Plugin, composables, and navigation guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -92,11 +92,11 @@ export const oidcPlugin = {
     };
 
     const refresh = async () => {
-      await client.refresh();
+      return client.refresh();
     };
 
     const doFetchProfile = async () => {
-      await client.fetchProfile();
+      return client.fetchProfile();
     };
 
     const actions: AuthActions = {

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -3,6 +3,7 @@ import type { OidcConfig } from "oidc-js-core";
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
 import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcUser } from "oidc-js-core";
 
 /**
  * Actions available for authentication operations.
@@ -16,9 +17,9 @@ export interface AuthActions {
   /** Logs the user out and redirects to the OP's end-session endpoint. */
   logout: () => void;
   /** Uses the stored refresh token to obtain a new set of tokens. */
-  refresh: () => Promise<void>;
+  refresh: () => Promise<AuthTokens>;
   /** Fetches the user's profile from the userinfo endpoint. */
-  fetchProfile: () => Promise<void>;
+  fetchProfile: () => Promise<OidcUser | null>;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`OidcClient.refresh()`** now returns `Promise<AuthTokens>` instead of `Promise<void>` — callers get the new token set immediately after await, no need to wait for framework state to propagate
- **`OidcClient.fetchProfile()`** now returns `Promise<OidcUser | null>` instead of `Promise<void>`
- **React `useAuth()`** now exposes `client: OidcClient` on the context value for direct state access outside the React tree
- Updated `AuthActions` types across all 8 framework adapters (React, Vue, Angular, Svelte, Solid, Preact, Lit, Kasper)
- Bumped all packages from 1.0.8 → 1.1.0

Closes #67, closes #68

## Test plan

- [ ] CI passes (unit tests, type checks, build)
- [ ] Verify `await actions.refresh()` returns `AuthTokens` in an axios interceptor
- [ ] Verify `client` is accessible from `useAuth()` in React

🤖 Generated with [Claude Code](https://claude.com/claude-code)