### PR TITLE
fix: warn when token lifetime is shorter than expiryBuffer

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -13,8 +13,10 @@ import {
   parseUserinfoResponse,
   buildLogoutUrl,
   decodeJwtPayload,
+  DEFAULT_EXPIRY_BUFFER,
   type OidcDiscovery,
   type OidcUser,
+  type TokenSet,
 } from "oidc-js-core";
 import { executeFetch } from "./fetch.js";
 import { saveAuthState, loadAuthState, clearAuthState } from "./storage.js";
@@ -24,6 +26,17 @@ import type { OidcClientConfig, AuthState, AuthUser, AuthTokens, IdTokenClaims, 
 type Subscriber = (state: AuthState) => void;
 
 const EMPTY_TOKENS: AuthTokens = { access: null, id: null, refresh: null, expiresAt: null };
+
+function warnIfShortLivedToken(tokenSet: TokenSet, expiryBuffer: number | undefined): void {
+  const buffer = expiryBuffer ?? DEFAULT_EXPIRY_BUFFER;
+  if (tokenSet.expires_in != null && tokenSet.expires_in <= buffer) {
+    console.warn(
+      `[oidc-js] Token lifetime (${tokenSet.expires_in}s) is shorter than expiryBuffer (${buffer}s). ` +
+      `This will cause the token to be treated as expired immediately. ` +
+      `Set a lower expiryBuffer in your config to avoid infinite refresh loops.`,
+    );
+  }
+}
 
 /**
  * Extracts the `exp` claim from an access token JWT.
@@ -136,6 +149,7 @@ export class OidcClient {
         const tokenReq = buildTokenRequest(this.discovery, this.config, code, authState.codeVerifier);
         const tokenData = await executeFetch(tokenReq, signal);
         const tokenSet = parseTokenResponse(tokenData, authState.nonce);
+        warnIfShortLivedToken(tokenSet, this.config.expiryBuffer);
 
         const newTokens: AuthTokens = {
           access: tokenSet.access_token,
@@ -265,6 +279,7 @@ export class OidcClient {
     const req = buildRefreshRequest(this.discovery, this.config, refreshToken);
     const data = await executeFetch(req);
     const tokenSet = parseTokenResponse(data);
+    warnIfShortLivedToken(tokenSet, this.config.expiryBuffer);
 
     const newTokens: AuthTokens = {
       access: tokenSet.access_token,

--- a/packages/core/src/tests/token-utils.test.ts
+++ b/packages/core/src/tests/token-utils.test.ts
@@ -63,6 +63,7 @@ describe("isExpiredAt", () => {
   it("DEFAULT_TOKEN_EXPIRATION_BUFFER is a deprecated alias", () => {
     expect(DEFAULT_TOKEN_EXPIRATION_BUFFER).toBe(DEFAULT_EXPIRY_BUFFER);
   });
+
 });
 
 describe("timeUntilExpiry", () => {


### PR DESCRIPTION
## Summary
- Adds a `console.warn` when the token endpoint returns `expires_in` shorter than the configured `expiryBuffer` (default 30s)
- Warns on both init (token exchange) and refresh paths
- Helps developers diagnose infinite refresh loops caused by short-lived tokens (e.g., admin sets 29s token lifetime with default 30s buffer)

## Context
Investigated how other OIDC libraries handle this (oidc-client-ts, MSAL.js, AppAuth-JS, angular-oauth2-oidc). None of them solve this properly — most just assume tokens live much longer than the buffer. Rather than adding complex capping logic that either breaks proactive refresh or changes function signatures across all adapters, a runtime warning is the pragmatic fix. All framework adapters (React, Vue, Angular, Svelte, etc.) go through `OidcClient`, so a single warning covers everything.

## Test plan
- [ ] Verify `pnpm --filter oidc-js-core test` passes
- [ ] Verify `pnpm --filter oidc-js build` succeeds
- [ ] Manual: configure a provider with short token lifetime (<30s) and confirm warning appears in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)