### PR TITLE
feat: proactive silent token refresh via setInterval polling

### DIFF
--- a/decisions.md
+++ b/decisions.md
@@ -315,3 +315,16 @@ Architectural and design decisions for the oidc-js project. Each entry captures 
 **Decision**: Option 3. `trackTraffic(page)` now returns `{ requests(), navigations(), sequence() }`. The sequence log records fetch requests as `GET /path` or `POST /path` and navigations as `NAV /path`, in the order Playwright observes them. All three are asserted in tests that check traffic.
 
 **Rationale**: The combined sequence is the source of truth for protocol ordering. The separate `requests()` and `navigations()` remain as convenience filters for tests that only need to check "which fetches happened" without reasoning about navigation interleaving. The assumed race condition from decision 023 turned out to be incorrect. Playwright's `page.on("request")` fires deterministically for both fetch and document requests, and the combined log is stable across runs. Named constants (`GET_WELLKNOWN`, `POST_TOKEN`, `GET_USERINFO`, `NAV_AUTHORIZE`, `NAV_LOGOUT`) make the sequence assertions read like a protocol spec.
+
+### 027 - Proactive token refresh via setInterval polling (2026-05-08)
+
+**Context**: Token expiration was only detected reactively — by `RequireAuth` at render time or by HTTP interceptors catching 401s. This meant consumers using plain `fetch` had to manually check for 401 on every request, and `RequireAuth` briefly unmounted children when it detected expiration (losing form state).
+
+**Alternatives considered**:
+1. Single `setTimeout` scheduled for `expiresAt - buffer` — simple but unreliable (browsers throttle background tabs, laptops sleep, timer fires late or not at all)
+2. `setInterval` polling with a short interval (e.g. 10s) that checks `Date.now() >= expiresAt - expiryBuffer` each tick
+3. Service Worker or `BroadcastChannel` based approach — complex, not universally supported
+
+**Decision**: Option 2. A `setInterval` in `OidcClient` polls every `autoRefreshInterval` seconds (default 10) and triggers `refresh()` when `isExpiredAt(expiresAt, expiryBuffer)` returns true. Enabled by default (`autoRefresh: true`). On refresh failure, the interval stops (no endpoint hammering); a successful manual refresh or new login restarts it.
+
+**Rationale**: This is the same approach `oidc-client-ts` uses (their `Timer` class polls every 5s). A short interval is drift-proof (always compares real time), sleep-proof (first tick after wake catches expiration), and cheap (one number comparison per tick). The implementation lives in `OidcClient`, so all framework adapters benefit via the existing subscribe/notify mechanism. The `expiryBuffer` config (already existed) controls how early the refresh fires — the token is still valid during the refresh request, so `RequireAuth` never sees an expired token and children stay mounted.

--- a/docs-web/src/content/docs/angular/provide-auth.mdx
+++ b/docs-web/src/content/docs/angular/provide-auth.mdx
@@ -38,7 +38,6 @@ bootstrapApplication(AppComponent, {
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `config` | `OidcConfig` | **required** | OIDC configuration (issuer, clientId, redirectUri, etc.) |
-| `fetchProfile` | `boolean` | `true` | Whether to fetch the UserInfo endpoint after login |
 | `onLogin` | `(returnTo: string) => void` | - | Called after successful login with the URL to restore |
 | `onError` | `(error: Error) => void` | - | Called when an error occurs during initialization |
 

--- a/docs-web/src/content/docs/guides/token-refresh.mdx
+++ b/docs-web/src/content/docs/guides/token-refresh.mdx
@@ -25,9 +25,42 @@ sequenceDiagram
     OidcClient->>App: Render protected content
 ```
 
-## Automatic refresh with RequireAuth
+## Proactive refresh
 
-`RequireAuth` handles refresh automatically. When a user navigates to a protected route with an expired token:
+By default, `OidcClient` proactively refreshes the access token *before* it expires using a short `setInterval` poll. Every tick compares the current time against `expiresAt - expiryBuffer` and triggers a refresh when the token is about to expire. This means the token is always fresh — no 401s, no interceptors needed, no fallback flash.
+
+This is enabled by default. You can configure the behavior with two options:
+
+```ts
+const config = {
+  issuer: "https://auth.example.com",
+  clientId: "my-app",
+  redirectUri: "http://localhost:5173/callback",
+  expiryBuffer: 60,           // refresh 60s before expiry (default: 30)
+  autoRefresh: true,           // enabled by default
+  autoRefreshInterval: 10,     // polling interval in seconds (default: 10)
+};
+```
+
+The polling interval is lightweight — one number comparison per tick, no re-renders or network calls until a refresh is actually needed. The approach is drift-proof and sleep-proof: after a laptop wakes from sleep, the very first tick catches the expiration.
+
+<Aside type="tip">
+If the refresh request fails (e.g. network error), the polling stops to avoid hammering the token endpoint. The auth state stays authenticated with the current token. A subsequent successful manual refresh (or a new login) restarts the polling automatically.
+</Aside>
+
+### Disabling proactive refresh
+
+Set `autoRefresh: false` to rely on reactive mechanisms instead (interceptors, `RequireAuth` re-mount):
+
+```tsx
+<AuthProvider config={{ ...config, autoRefresh: false }}>
+  <App />
+</AuthProvider>
+```
+
+## Reactive refresh with RequireAuth
+
+`RequireAuth` handles refresh reactively. When a user navigates to a protected route with an expired token:
 
 1. Checks `tokens.expiresAt` using `isExpiredAt()` from core (with an optional buffer)
 2. If expired, calls `actions.refresh()`
@@ -47,6 +80,10 @@ You can set an `expiryBuffer` (in seconds) on the provider config to refresh the
   <App />
 </AuthProvider>
 ```
+
+<Aside type="note">
+With proactive refresh enabled (the default), `RequireAuth` rarely needs to trigger a refresh because the token is typically renewed before it expires. It serves as a safety net for edge cases like initial page load with a stale token.
+</Aside>
 
 ## Manual refresh
 

--- a/docs-web/src/content/docs/guides/user-profile.mdx
+++ b/docs-web/src/content/docs/guides/user-profile.mdx
@@ -35,7 +35,7 @@ user?.profile?.preferred_username;
 By default, `AuthProvider` fetches the user profile after login. You can disable this:
 
 ```tsx
-<AuthProvider config={config} fetchProfile={false}>
+<AuthProvider config={{ ...config, fetchProfile: false }}>
   <App />
 </AuthProvider>
 ```

--- a/docs-web/src/content/docs/lit/auth-controller.mdx
+++ b/docs-web/src/content/docs/lit/auth-controller.mdx
@@ -46,7 +46,6 @@ customElements.define("my-app", MyApp);
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `config` | `OidcConfig` | **required** | OIDC configuration (issuer, clientId, redirectUri, etc.) |
-| `fetchProfile` | `boolean` | `true` | Whether to fetch the UserInfo endpoint after login |
 | `onLogin` | `(returnTo: string) => void` | - | Called after successful login with the URL to restore |
 | `onError` | `(error: Error) => void` | - | Called when an error occurs during initialization |
 

--- a/docs-web/src/content/docs/preact/auth-provider.mdx
+++ b/docs-web/src/content/docs/preact/auth-provider.mdx
@@ -38,7 +38,6 @@ function App() {
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `config` | `OidcConfig` | **required** | OIDC configuration (issuer, clientId, redirectUri, etc.) |
-| `fetchProfile` | `boolean` | `true` | Whether to fetch the UserInfo endpoint after login |
 | `onLogin` | `(returnTo: string) => void` | - | Called after successful login with the URL to restore |
 | `onError` | `(error: Error) => void` | - | Called when an error occurs during initialization |
 | `children` | `ComponentChildren` | **required** | Child components |

--- a/docs-web/src/content/docs/react/auth-provider.mdx
+++ b/docs-web/src/content/docs/react/auth-provider.mdx
@@ -34,7 +34,6 @@ function App() {
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `config` | `OidcConfig` | **required** | OIDC configuration (issuer, clientId, redirectUri, etc.) |
-| `fetchProfile` | `boolean` | `true` | Whether to fetch the UserInfo endpoint after login |
 | `onLogin` | `(returnTo: string) => void` | — | Called after successful login with the URL to restore |
 | `onError` | `(error: Error) => void` | — | Called when an error occurs during initialization |
 | `children` | `ReactNode` | **required** | Child components |

--- a/docs-web/src/content/docs/react/use-auth.mdx
+++ b/docs-web/src/content/docs/react/use-auth.mdx
@@ -49,7 +49,7 @@ interface AuthUser {
 }
 ```
 
-`null` when not authenticated. After login, `claims` is always populated from the ID token. `profile` is populated from the UserInfo endpoint if `fetchProfile` is `true` (default).
+`null` when not authenticated. After login, `claims` is always populated from the ID token. `profile` is populated from the UserInfo endpoint if `config.fetchProfile` is `true` (default).
 
 ### tokens
 

--- a/docs-web/src/content/docs/solid/auth-provider.mdx
+++ b/docs-web/src/content/docs/solid/auth-provider.mdx
@@ -38,7 +38,6 @@ function App() {
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `config` | `OidcConfig` | **required** | OIDC configuration (issuer, clientId, redirectUri, etc.) |
-| `fetchProfile` | `boolean` | `true` | Whether to fetch the UserInfo endpoint after login |
 | `onLogin` | `(returnTo: string) => void` | - | Called after successful login with the URL to restore |
 | `onError` | `(error: Error) => void` | - | Called when an error occurs during initialization |
 | `children` | `JSX.Element` | **required** | Child components |

--- a/docs-web/src/content/docs/svelte/auth-provider.mdx
+++ b/docs-web/src/content/docs/svelte/auth-provider.mdx
@@ -36,7 +36,6 @@ npm install oidc-js-svelte
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `config` | `OidcConfig` | **required** | OIDC configuration (issuer, clientId, redirectUri, etc.) |
-| `fetchProfile` | `boolean` | `true` | Whether to fetch the UserInfo endpoint after login |
 | `onLogin` | `(returnTo: string) => void` | - | Called after successful login with the URL to restore |
 | `onError` | `(error: Error) => void` | - | Called when an error occurs during initialization |
 | `children` | `Snippet` | **required** | Child content to render |

--- a/docs-web/src/content/docs/vue/plugin.mdx
+++ b/docs-web/src/content/docs/vue/plugin.mdx
@@ -38,7 +38,6 @@ app.mount("#app");
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `config` | `OidcConfig` | **required** | OIDC configuration (issuer, clientId, redirectUri, etc.) |
-| `fetchProfile` | `boolean` | `true` | Whether to fetch the UserInfo endpoint after login |
 | `onLogin` | `(returnTo: string) => void` | - | Called after successful login with the URL to restore |
 | `onError` | `(error: Error) => void` | - | Called when an error occurs during initialization |
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-angular",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Simple OIDC authentication for Angular. Signals, DI, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/angular/src/auth.service.ts
+++ b/packages/angular/src/auth.service.ts
@@ -63,10 +63,7 @@ export class AuthService {
     this.router = inject(Router);
     const destroyRef = inject(DestroyRef);
 
-    this.client = new OidcClient({
-      ...this.options.config,
-      fetchProfile: this.options.fetchProfile,
-    });
+    this.client = new OidcClient(this.options.config);
 
     const unsub = this.client.subscribe((state: AuthState) => {
       this._user.set(state.user);

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -10,4 +10,5 @@ export type {
   LoginOptions,
 } from "./types.js";
 
+export type { OidcClientConfig } from "oidc-js";
 export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/angular/src/tests/auth.service.test.ts
+++ b/packages/angular/src/tests/auth.service.test.ts
@@ -43,8 +43,7 @@ const CONFIG = {
 };
 
 const mockOptions: Record<string, unknown> = {
-  config: CONFIG,
-  fetchProfile: true,
+  config: { ...CONFIG, fetchProfile: true },
 };
 
 vi.mock("@angular/core", () => {

--- a/packages/angular/src/types.ts
+++ b/packages/angular/src/types.ts
@@ -11,8 +11,6 @@ import type { OidcClientConfig } from "oidc-js";
 export interface AuthProviderOptions {
   /** Core OIDC configuration (issuer, clientId, redirectUri, scopes, etc.). */
   config: OidcClientConfig;
-  /** Whether to fetch the userinfo profile after token exchange. Defaults to `true`. */
-  fetchProfile?: boolean;
   /**
    * Called after a successful login callback with the `returnTo` path.
    * If not provided, the adapter uses Angular's `Router.navigateByUrl` to navigate.

--- a/packages/angular/src/types.ts
+++ b/packages/angular/src/types.ts
@@ -1,6 +1,6 @@
-import type { OidcConfig } from "oidc-js-core";
-
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+
+import type { OidcClientConfig } from "oidc-js";
 
 /**
  * Configuration options for {@link provideAuth}.
@@ -10,7 +10,7 @@ export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js"
  */
 export interface AuthProviderOptions {
   /** Core OIDC configuration (issuer, clientId, redirectUri, scopes, etc.). */
-  config: OidcConfig;
+  config: OidcClientConfig;
   /** Whether to fetch the userinfo profile after token exchange. Defaults to `true`. */
   fetchProfile?: boolean;
   /**

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Simple OIDC authentication for JavaScript. Drop-in client with login, logout, token refresh, and zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -13,6 +13,7 @@ import {
   parseUserinfoResponse,
   buildLogoutUrl,
   decodeJwtPayload,
+  isExpiredAt,
   DEFAULT_EXPIRY_BUFFER,
   type OidcDiscovery,
   type OidcUser,
@@ -65,6 +66,7 @@ export class OidcClient {
   private subscribers = new Set<Subscriber>();
   private abortController: AbortController | null = null;
   private refreshPromise: Promise<AuthTokens> | null = null;
+  private autoRefreshTimer: ReturnType<typeof setInterval> | null = null;
 
   private _state: AuthState = {
     user: null,
@@ -178,6 +180,8 @@ export class OidcClient {
           isLoading: false,
         });
 
+        this.startAutoRefresh();
+
         return { returnTo };
       }
 
@@ -228,6 +232,7 @@ export class OidcClient {
    * with the current ID token hint and `postLogoutRedirectUri` from config.
    */
   logout(): void {
+    this.stopAutoRefresh();
     const idToken = this._state.tokens.id;
 
     this.setState({
@@ -305,6 +310,8 @@ export class OidcClient {
       error: null,
     });
 
+    this.startAutoRefresh();
+
     return newTokens;
   }
 
@@ -331,8 +338,32 @@ export class OidcClient {
    * Tears down the client by aborting any in-flight requests and removing all subscribers.
    */
   destroy(): void {
+    this.stopAutoRefresh();
     this.abortController?.abort();
     this.subscribers.clear();
+  }
+
+  private startAutoRefresh(): void {
+    if (this.config.autoRefresh === false) return;
+    if (this.autoRefreshTimer) return;
+
+    const intervalSeconds = this.config.autoRefreshInterval ?? 10;
+    const buffer = this.config.expiryBuffer ?? DEFAULT_EXPIRY_BUFFER;
+
+    this.autoRefreshTimer = setInterval(() => {
+      const { expiresAt } = this._state.tokens;
+      if (!this._state.isAuthenticated || !this._state.tokens.refresh) return;
+      if (!isExpiredAt(expiresAt, buffer)) return;
+
+      this.refresh().catch(() => { this.stopAutoRefresh(); });
+    }, intervalSeconds * 1000);
+  }
+
+  private stopAutoRefresh(): void {
+    if (this.autoRefreshTimer) {
+      clearInterval(this.autoRefreshTimer);
+      this.autoRefreshTimer = null;
+    }
   }
 
   /**

--- a/packages/client/src/tests/client.test.ts
+++ b/packages/client/src/tests/client.test.ts
@@ -330,4 +330,174 @@ describe("OidcClient", () => {
       expect(fn).not.toHaveBeenCalled();
     });
   });
+
+  describe("autoRefresh", () => {
+    function setupAuthenticatedClient(configOverrides?: Partial<OidcClientConfig>) {
+      Object.defineProperty(window, "location", {
+        value: {
+          href: "http://localhost:3000?code=auth_code&state=test-state",
+          search: "?code=auth_code&state=test-state",
+          pathname: "/",
+          hash: "",
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      sessionStorage.setItem(
+        "oidc-js:auth-state",
+        JSON.stringify({
+          codeVerifier: "test-verifier",
+          state: "test-state",
+          nonce: "test-nonce",
+          redirectUri: "http://localhost:3000/callback",
+        }),
+      );
+
+      return new OidcClient({ ...CONFIG, fetchProfile: false, ...configOverrides });
+    }
+
+    it("calls refresh when token is near expiry", async () => {
+      const expiringSoonToken = makeJwt({ sub: "user-1", exp: nowSeconds() + 10 });
+      const tokenResponse = { ...TOKEN_RESPONSE, access_token: expiringSoonToken };
+      mockFetchResponses(DISCOVERY, tokenResponse);
+
+      const client = setupAuthenticatedClient({ autoRefreshInterval: 0.1, expiryBuffer: 30 });
+      await client.init();
+
+      const freshToken = makeJwt({ sub: "user-1", exp: nowSeconds() + 7200 });
+      mockFetchResponses({
+        access_token: freshToken,
+        token_type: "Bearer",
+        refresh_token: "rt_new",
+      });
+
+      await vi.waitFor(() => {
+        expect(client.state.tokens.access).toBe(freshToken);
+      }, { timeout: 1000 });
+
+      client.destroy();
+    });
+
+    it("does not refresh when token is not near expiry", async () => {
+      mockFetchResponses(DISCOVERY, TOKEN_RESPONSE);
+
+      const client = setupAuthenticatedClient({ autoRefreshInterval: 0.1 });
+      await client.init();
+
+      const callCountAfterInit = fetchMock.mock.calls.length;
+
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(fetchMock.mock.calls.length).toBe(callCountAfterInit);
+
+      client.destroy();
+    });
+
+    it("does not start when autoRefresh is false", async () => {
+      const expiringSoonToken = makeJwt({ sub: "user-1", exp: nowSeconds() + 10 });
+      const tokenResponse = { ...TOKEN_RESPONSE, access_token: expiringSoonToken };
+      mockFetchResponses(DISCOVERY, tokenResponse);
+
+      const client = setupAuthenticatedClient({ autoRefresh: false, autoRefreshInterval: 0.1, expiryBuffer: 30 });
+      await client.init();
+
+      const callCountAfterInit = fetchMock.mock.calls.length;
+
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(fetchMock.mock.calls.length).toBe(callCountAfterInit);
+
+      client.destroy();
+    });
+
+    it("stops on logout", async () => {
+      const expiringSoonToken = makeJwt({ sub: "user-1", exp: nowSeconds() + 10 });
+      const tokenResponse = { ...TOKEN_RESPONSE, access_token: expiringSoonToken };
+      mockFetchResponses(DISCOVERY, tokenResponse);
+
+      const client = setupAuthenticatedClient({ autoRefreshInterval: 0.1, expiryBuffer: 30 });
+      await client.init();
+
+      client.logout();
+
+      const callCountAfterLogout = fetchMock.mock.calls.length;
+
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(fetchMock.mock.calls.length).toBe(callCountAfterLogout);
+    });
+
+    it("stops polling after a failed refresh", async () => {
+      const expiringSoonToken = makeJwt({ sub: "user-1", exp: nowSeconds() + 10 });
+      const tokenResponse = { ...TOKEN_RESPONSE, access_token: expiringSoonToken };
+      mockFetchResponses(DISCOVERY, tokenResponse);
+
+      const client = setupAuthenticatedClient({ autoRefreshInterval: 0.1, expiryBuffer: 30 });
+      await client.init();
+
+      fetchMock.mockRejectedValueOnce(new Error("network error"));
+
+      await vi.waitFor(() => {
+        expect(fetchMock.mock.calls.length).toBeGreaterThan(2);
+      }, { timeout: 1000 });
+
+      const callCountAfterFailure = fetchMock.mock.calls.length;
+
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(fetchMock.mock.calls.length).toBe(callCountAfterFailure);
+      expect(client.state.isAuthenticated).toBe(true);
+
+      client.destroy();
+    });
+
+    it("restarts after a failed auto-refresh followed by a manual refresh", async () => {
+      const expiringSoonToken = makeJwt({ sub: "user-1", exp: nowSeconds() + 10 });
+      const tokenResponse = { ...TOKEN_RESPONSE, access_token: expiringSoonToken };
+      mockFetchResponses(DISCOVERY, tokenResponse);
+
+      const client = setupAuthenticatedClient({ autoRefreshInterval: 0.1, expiryBuffer: 30 });
+      await client.init();
+
+      // Auto-refresh fires and fails → interval stops
+      fetchMock.mockRejectedValueOnce(new Error("network error"));
+
+      await vi.waitFor(() => {
+        expect(fetchMock.mock.calls.length).toBeGreaterThan(2);
+      }, { timeout: 1000 });
+
+      // Manual refresh succeeds → interval restarts
+      const freshToken = makeJwt({ sub: "user-1", exp: nowSeconds() + 10 });
+      mockFetchResponses({ access_token: freshToken, token_type: "Bearer", refresh_token: "rt_new" });
+      await client.refresh();
+
+      // Auto-refresh should fire again with the new (still near-expiry) token
+      const secondFreshToken = makeJwt({ sub: "user-1", exp: nowSeconds() + 7200 });
+      mockFetchResponses({ access_token: secondFreshToken, token_type: "Bearer", refresh_token: "rt_new2" });
+
+      await vi.waitFor(() => {
+        expect(client.state.tokens.access).toBe(secondFreshToken);
+      }, { timeout: 1000 });
+
+      client.destroy();
+    });
+
+    it("stops on destroy", async () => {
+      const expiringSoonToken = makeJwt({ sub: "user-1", exp: nowSeconds() + 10 });
+      const tokenResponse = { ...TOKEN_RESPONSE, access_token: expiringSoonToken };
+      mockFetchResponses(DISCOVERY, tokenResponse);
+
+      const client = setupAuthenticatedClient({ autoRefreshInterval: 0.1, expiryBuffer: 30 });
+      await client.init();
+
+      client.destroy();
+
+      const callCountAfterDestroy = fetchMock.mock.calls.length;
+
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(fetchMock.mock.calls.length).toBe(callCountAfterDestroy);
+    });
+  });
 });

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -60,6 +60,10 @@ export interface LoginOptions {
 export interface OidcClientConfig extends OidcConfig {
   /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
   fetchProfile?: boolean;
+  /** Whether to proactively refresh the access token before it expires. Defaults to true. */
+  autoRefresh?: boolean;
+  /** Polling interval in seconds for the auto-refresh check. Defaults to 10. */
+  autoRefreshInterval?: number;
 }
 
 /**

--- a/packages/kasper/package.json
+++ b/packages/kasper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-kasper",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Simple OIDC authentication for Kasper.js. Signals, components, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/kasper/src/auth-provider.ts
+++ b/packages/kasper/src/auth-provider.ts
@@ -1,10 +1,10 @@
 import { Component } from "kasper-js";
-import type { OidcConfig } from "oidc-js-core";
+import type { OidcClientConfig } from "oidc-js";
 import type { OidcClient } from "oidc-js";
 import { _initAuth, _destroyAuth } from "./context.js";
 
 interface AuthProviderArgs {
-  config: OidcConfig;
+  config: OidcClientConfig;
   fetchProfile?: boolean;
   onLogin?: (returnTo: string) => void;
   onError?: (error: Error) => void;

--- a/packages/kasper/src/auth-provider.ts
+++ b/packages/kasper/src/auth-provider.ts
@@ -5,7 +5,6 @@ import { _initAuth, _destroyAuth } from "./context.js";
 
 interface AuthProviderArgs {
   config: OidcClientConfig;
-  fetchProfile?: boolean;
   onLogin?: (returnTo: string) => void;
   onError?: (error: Error) => void;
 }
@@ -29,11 +28,10 @@ export class AuthProvider extends Component<AuthProviderArgs> {
 
   onMount(): void {
     const config = this.args.config;
-    const fetchProfile = this.args.fetchProfile ?? true;
     const onLogin = this.args.onLogin;
     const onError = this.args.onError;
 
-    const { client, unsub } = _initAuth(config, fetchProfile);
+    const { client, unsub } = _initAuth(config);
     this._client = client;
     this._unsub = unsub;
 

--- a/packages/kasper/src/context.ts
+++ b/packages/kasper/src/context.ts
@@ -21,9 +21,8 @@ let _unsub: (() => void) | null = null;
 /** @internal */
 export function _initAuth(
   config: OidcClientConfig,
-  fetchProfile: boolean,
 ): { client: OidcClient; unsub: () => void } {
-  const client = new OidcClient({ ...config, fetchProfile });
+  const client = new OidcClient(config);
   _client = client;
   _config = config;
   _actions = {

--- a/packages/kasper/src/context.ts
+++ b/packages/kasper/src/context.ts
@@ -1,6 +1,5 @@
 import { signal, batch } from "kasper-js";
-import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
-import type { OidcConfig } from "oidc-js-core";
+import { OidcClient, type OidcClientConfig, type AuthState, type LoginOptions } from "oidc-js";
 import type { AuthContextValue, AuthActions } from "./types.js";
 
 const _user = signal<AuthState["user"]>(null);
@@ -15,13 +14,13 @@ const _tokens = signal<AuthState["tokens"]>({
 });
 
 let _client: OidcClient | null = null;
-let _config: OidcConfig | null = null;
+let _config: OidcClientConfig | null = null;
 let _actions: AuthActions | null = null;
 let _unsub: (() => void) | null = null;
 
 /** @internal */
 export function _initAuth(
-  config: OidcConfig,
+  config: OidcClientConfig,
   fetchProfile: boolean,
 ): { client: OidcClient; unsub: () => void } {
   const client = new OidcClient({ ...config, fetchProfile });

--- a/packages/kasper/src/index.ts
+++ b/packages/kasper/src/index.ts
@@ -10,4 +10,5 @@ export type {
   Signal,
   LoginOptions,
 } from "./types.js";
+export type { OidcClientConfig } from "oidc-js";
 export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/kasper/src/tests/auth-provider.test.ts
+++ b/packages/kasper/src/tests/auth-provider.test.ts
@@ -27,7 +27,7 @@ vi.mock("oidc-js", () => ({
 import { AuthProvider } from "../auth-provider.js";
 import { _destroyAuth, useAuth } from "../context.js";
 
-const CONFIG: OidcConfig = {
+const CONFIG: OidcClientConfig = {
   issuer: "https://auth.example.com",
   clientId: "my-app",
   redirectUri: "http://localhost:3000/callback",

--- a/packages/kasper/src/tests/auth-provider.test.ts
+++ b/packages/kasper/src/tests/auth-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { OidcConfig } from "oidc-js-core";
+import type { OidcClientConfig } from "oidc-js";
 
 const mockClientInstance = {
   subscribe: vi.fn((_cb: (state: unknown) => void) => vi.fn()),
@@ -45,8 +45,7 @@ afterEach(() => {
 });
 
 interface AuthProviderArgs {
-  config: OidcConfig;
-  fetchProfile?: boolean;
+  config: OidcClientConfig;
   onLogin?: (returnTo: string) => void;
   onError?: (error: Error) => void;
 }
@@ -71,14 +70,14 @@ describe("AuthProvider", () => {
     expect(mockClientInstance.init).toHaveBeenCalled();
   });
 
-  it("defaults fetchProfile to true", async () => {
+  it("passes config directly to OidcClient", async () => {
     const { OidcClient } =
       await vi.importMock<typeof import("oidc-js")>("oidc-js");
 
     const provider = createProvider({ config: CONFIG });
     provider.onMount();
 
-    expect(OidcClient).toHaveBeenCalledWith({ ...CONFIG, fetchProfile: true });
+    expect(OidcClient).toHaveBeenCalledWith(CONFIG);
   });
 
   it("passes fetchProfile=false when configured", async () => {
@@ -86,8 +85,7 @@ describe("AuthProvider", () => {
       await vi.importMock<typeof import("oidc-js")>("oidc-js");
 
     const provider = createProvider({
-      config: CONFIG,
-      fetchProfile: false,
+      config: { ...CONFIG, fetchProfile: false },
     });
     provider.onMount();
 

--- a/packages/kasper/src/tests/context.test.ts
+++ b/packages/kasper/src/tests/context.test.ts
@@ -52,7 +52,7 @@ describe("useAuth", () => {
   });
 
   it("returns auth context after _initAuth", () => {
-    _initAuth(CONFIG, true);
+    _initAuth(CONFIG);
     const auth = useAuth();
 
     expect(auth.config).toEqual(CONFIG);
@@ -69,7 +69,7 @@ describe("useAuth", () => {
   });
 
   it("exposes actions that delegate to OidcClient", () => {
-    _initAuth(CONFIG, true);
+    _initAuth(CONFIG);
     const auth = useAuth();
 
     auth.actions.login();
@@ -87,25 +87,25 @@ describe("useAuth", () => {
 });
 
 describe("_initAuth", () => {
-  it("creates OidcClient with config and fetchProfile", async () => {
+  it("creates OidcClient with config", async () => {
     const { OidcClient } = await vi.importMock<typeof import("oidc-js")>(
       "oidc-js",
     );
 
-    _initAuth(CONFIG, true);
+    _initAuth(CONFIG);
 
-    expect(OidcClient).toHaveBeenCalledWith({ ...CONFIG, fetchProfile: true });
+    expect(OidcClient).toHaveBeenCalledWith(CONFIG);
   });
 
   it("returns client and unsub function", () => {
-    const result = _initAuth(CONFIG, false);
+    const result = _initAuth(CONFIG);
 
     expect(result.client).toBe(mockClientInstance);
     expect(typeof result.unsub).toBe("function");
   });
 
   it("subscribes to client state changes", () => {
-    _initAuth(CONFIG, true);
+    _initAuth(CONFIG);
 
     expect(mockClientInstance.subscribe).toHaveBeenCalledWith(
       expect.any(Function),
@@ -113,7 +113,7 @@ describe("_initAuth", () => {
   });
 
   it("updates signals when subscriber fires", () => {
-    _initAuth(CONFIG, true);
+    _initAuth(CONFIG);
     const subscriber = mockClientInstance.subscribe.mock.calls[0][0];
 
     subscriber({
@@ -134,7 +134,7 @@ describe("_initAuth", () => {
 
 describe("_destroyAuth", () => {
   it("resets all signals to initial values", () => {
-    _initAuth(CONFIG, true);
+    _initAuth(CONFIG);
     const subscriber = mockClientInstance.subscribe.mock.calls[0][0];
 
     subscriber({
@@ -158,7 +158,7 @@ describe("logout unsubscribes before calling client", () => {
     const unsubFn = vi.fn();
     mockClientInstance.subscribe.mockReturnValueOnce(unsubFn);
 
-    _initAuth(CONFIG, true);
+    _initAuth(CONFIG);
     const auth = useAuth();
 
     auth.actions.logout();

--- a/packages/kasper/src/types.ts
+++ b/packages/kasper/src/types.ts
@@ -1,6 +1,5 @@
 import type { Signal } from "kasper-js";
-import type { OidcConfig } from "oidc-js-core";
-import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcClientConfig, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 import type { OidcUser } from "oidc-js-core";
 
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
@@ -21,7 +20,7 @@ export interface AuthActions {
 /** Value returned by {@link useAuth}. All state properties are Kasper signals. */
 export interface AuthContextValue {
   /** The OIDC configuration used to initialize the provider. */
-  readonly config: OidcConfig;
+  readonly config: OidcClientConfig;
   /** The authenticated user, or null if not authenticated. */
   readonly user: Signal<AuthUser | null>;
   /** Whether the user is currently authenticated. */

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-lit",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Simple OIDC authentication for Lit. Reactive controllers for login, logout, and token refresh with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/lit/src/auth-controller.ts
+++ b/packages/lit/src/auth-controller.ts
@@ -1,6 +1,5 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
-import { OidcClient, type AuthState, type AuthUser, type AuthTokens, type LoginOptions } from "oidc-js";
-import type { OidcConfig } from "oidc-js-core";
+import { OidcClient, type OidcClientConfig, type AuthState, type AuthUser, type AuthTokens, type LoginOptions } from "oidc-js";
 import type { AuthControllerOptions } from "./types.js";
 
 /**
@@ -85,7 +84,7 @@ export class AuthController implements ReactiveController {
   }
 
   /** The OIDC configuration passed to this controller. */
-  get config(): OidcConfig {
+  get config(): OidcClientConfig {
     return this.options.config;
   }
 

--- a/packages/lit/src/auth-controller.ts
+++ b/packages/lit/src/auth-controller.ts
@@ -93,8 +93,8 @@ export class AuthController implements ReactiveController {
    * Creates the {@link OidcClient}, subscribes to state changes, and initializes the OIDC flow.
    */
   hostConnected(): void {
-    const { config, fetchProfile, onLogin, onError } = this.options;
-    const client = new OidcClient({ ...config, fetchProfile });
+    const { config, onLogin, onError } = this.options;
+    const client = new OidcClient(config);
     this.client = client;
 
     this.unsubscribe = client.subscribe((state: AuthState) => {

--- a/packages/lit/src/index.ts
+++ b/packages/lit/src/index.ts
@@ -12,4 +12,5 @@ export type {
 
 export type { RequireAuthOptions } from "./require-auth.js";
 
+export type { OidcClientConfig } from "oidc-js";
 export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/lit/src/tests/auth-controller.test.ts
+++ b/packages/lit/src/tests/auth-controller.test.ts
@@ -89,7 +89,7 @@ describe("AuthController", () => {
     const { OidcClient } = await vi.importMock<typeof import("oidc-js")>("oidc-js");
 
     const host = createMockHost();
-    const ctrl = new AuthController(host, { config: CONFIG, fetchProfile: false });
+    const ctrl = new AuthController(host, { config: { ...CONFIG, fetchProfile: false } });
     ctrl.hostConnected();
 
     expect(OidcClient).toHaveBeenCalledWith({ ...CONFIG, fetchProfile: false });

--- a/packages/lit/src/types.ts
+++ b/packages/lit/src/types.ts
@@ -1,8 +1,6 @@
-import type { OidcConfig } from "oidc-js-core";
-
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
-import type { AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcClientConfig, AuthTokens, LoginOptions } from "oidc-js";
 import type { OidcUser } from "oidc-js-core";
 
 /**
@@ -24,7 +22,7 @@ export interface AuthActions {
  */
 export interface AuthControllerOptions {
   /** OIDC configuration including issuer, clientId, and redirectUri. */
-  config: OidcConfig;
+  config: OidcClientConfig;
   /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
   fetchProfile?: boolean;
   /**

--- a/packages/lit/src/types.ts
+++ b/packages/lit/src/types.ts
@@ -23,8 +23,6 @@ export interface AuthActions {
 export interface AuthControllerOptions {
   /** OIDC configuration including issuer, clientId, and redirectUri. */
   config: OidcClientConfig;
-  /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
-  fetchProfile?: boolean;
   /**
    * Called after a successful login callback with the `returnTo` path.
    * If not provided, the controller calls `window.history.replaceState` to update the URL.

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-preact",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Simple OIDC authentication for Preact. Hooks, provider, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/preact/src/context.tsx
+++ b/packages/preact/src/context.tsx
@@ -15,7 +15,6 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 interface AuthProviderProps {
   config: OidcClientConfig;
-  fetchProfile?: boolean;
   onLogin?: (returnTo: string) => void;
   onError?: (error: Error) => void;
   children: ComponentChildren;
@@ -31,7 +30,6 @@ interface AuthProviderProps {
  */
 export function AuthProvider({
   config,
-  fetchProfile = true,
   onLogin,
   onError,
   children,
@@ -52,7 +50,7 @@ export function AuthProvider({
   onErrorRef.current = onError;
 
   useEffect(() => {
-    const client = new OidcClient({ ...config, fetchProfile });
+    const client = new OidcClient(config);
     clientRef.current = client;
 
     const unsub = client.subscribe(setState);
@@ -73,7 +71,7 @@ export function AuthProvider({
       unsub();
       client.destroy();
     };
-  }, [config, fetchProfile]);
+  }, [config]);
 
   const login = useCallback(
     async (options?: LoginOptions) => {

--- a/packages/preact/src/context.tsx
+++ b/packages/preact/src/context.tsx
@@ -8,14 +8,13 @@ import {
   useMemo,
 } from "preact/hooks";
 import type { ComponentChildren } from "preact";
-import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
-import type { OidcConfig } from "oidc-js-core";
+import { OidcClient, type OidcClientConfig, type AuthState, type LoginOptions } from "oidc-js";
 import type { AuthContextValue } from "./types.js";
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 interface AuthProviderProps {
-  config: OidcConfig;
+  config: OidcClientConfig;
   fetchProfile?: boolean;
   onLogin?: (returnTo: string) => void;
   onError?: (error: Error) => void;

--- a/packages/preact/src/index.ts
+++ b/packages/preact/src/index.ts
@@ -10,4 +10,5 @@ export type {
   LoginOptions,
 } from "./types.js";
 
+export type { OidcClientConfig } from "oidc-js";
 export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/preact/src/tests/context.test.tsx
+++ b/packages/preact/src/tests/context.test.tsx
@@ -177,7 +177,7 @@ describe("AuthProvider", () => {
     }
 
     render(
-      h(AuthProvider, { config: CONFIG, fetchProfile: true }, h(Consumer, null)),
+      h(AuthProvider, { config: { ...CONFIG, fetchProfile: true } }, h(Consumer, null)),
     );
 
     await waitFor(() => {
@@ -245,7 +245,7 @@ describe("AuthProvider", () => {
     }
 
     render(
-      h(AuthProvider, { config: CONFIG, fetchProfile: false }, h(Consumer, null)),
+      h(AuthProvider, { config: { ...CONFIG, fetchProfile: false } }, h(Consumer, null)),
     );
 
     await waitFor(() => {

--- a/packages/preact/src/types.ts
+++ b/packages/preact/src/types.ts
@@ -1,8 +1,6 @@
-import type { OidcConfig } from "oidc-js-core";
-
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
-import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcClientConfig, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 import type { OidcUser } from "oidc-js-core";
 
 /** Actions available for controlling the authentication lifecycle. */
@@ -20,7 +18,7 @@ export interface AuthActions {
 /** The value provided by {@link AuthProvider} and consumed by {@link useAuth}. */
 export interface AuthContextValue {
   /** The OIDC configuration used by the provider. */
-  config: OidcConfig;
+  config: OidcClientConfig;
   /** The authenticated user, or null if not logged in. */
   user: AuthUser | null;
   /** Whether the user is currently authenticated. */

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-react",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Simple OIDC authentication for React. Provider, hooks, and route guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -15,7 +15,6 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 interface AuthProviderProps {
   config: OidcClientConfig;
-  fetchProfile?: boolean;
   onLogin?: (returnTo: string) => void;
   onError?: (error: Error) => void;
   children: ReactNode;
@@ -23,7 +22,6 @@ interface AuthProviderProps {
 
 export function AuthProvider({
   config,
-  fetchProfile = true,
   onLogin,
   onError,
   children,
@@ -44,7 +42,7 @@ export function AuthProvider({
   onErrorRef.current = onError;
 
   useEffect(() => {
-    const client = new OidcClient({ ...config, fetchProfile });
+    const client = new OidcClient(config);
     clientRef.current = client;
 
     const unsub = client.subscribe(setState);
@@ -65,7 +63,7 @@ export function AuthProvider({
       unsub();
       client.destroy();
     };
-  }, [config, fetchProfile]);
+  }, [config]);
 
   const login = useCallback(
     async (options?: LoginOptions) => {

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -8,14 +8,13 @@ import {
   useMemo,
   type ReactNode,
 } from "react";
-import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
-import type { OidcConfig } from "oidc-js-core";
+import { OidcClient, type OidcClientConfig, type AuthState, type LoginOptions } from "oidc-js";
 import type { AuthContextValue } from "./types.js";
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
 interface AuthProviderProps {
-  config: OidcConfig;
+  config: OidcClientConfig;
   fetchProfile?: boolean;
   onLogin?: (returnTo: string) => void;
   onError?: (error: Error) => void;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,4 +10,5 @@ export type {
   LoginOptions,
 } from "./types.js";
 
+export type { OidcClientConfig } from "oidc-js";
 export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/react/src/tests/context.test.tsx
+++ b/packages/react/src/tests/context.test.tsx
@@ -91,7 +91,7 @@ function wrapper({ children }: { children: ReactNode }) {
 
 function wrapperWithProfile({ children }: { children: ReactNode }) {
   return (
-    <AuthProvider config={CONFIG} fetchProfile={true}>
+    <AuthProvider config={{ ...CONFIG, fetchProfile: true }}>
       {children}
     </AuthProvider>
   );
@@ -99,7 +99,7 @@ function wrapperWithProfile({ children }: { children: ReactNode }) {
 
 function wrapperNoProfile({ children }: { children: ReactNode }) {
   return (
-    <AuthProvider config={CONFIG} fetchProfile={false}>
+    <AuthProvider config={{ ...CONFIG, fetchProfile: false }}>
       {children}
     </AuthProvider>
   );

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,8 +1,6 @@
-import type { OidcConfig } from "oidc-js-core";
-
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
-import type { OidcClient, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcClient, OidcClientConfig, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 import type { OidcUser } from "oidc-js-core";
 
 export interface AuthActions {
@@ -13,7 +11,7 @@ export interface AuthActions {
 }
 
 export interface AuthContextValue {
-  config: OidcConfig;
+  config: OidcClientConfig;
   client: OidcClient;
   user: AuthUser | null;
   isAuthenticated: boolean;

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-solid",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Simple OIDC authentication for SolidJS. Signals, context, and auth guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/solid/src/context.tsx
+++ b/packages/solid/src/context.tsx
@@ -17,8 +17,6 @@ const AuthContext = createContext<AuthContextValue>();
 interface AuthProviderProps {
   /** OIDC configuration including issuer, clientId, and redirectUri. */
   config: OidcClientConfig;
-  /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
-  fetchProfile?: boolean;
   /** Callback invoked after a successful login with the returnTo path. */
   onLogin?: (returnTo: string) => void;
   /** Callback invoked when an authentication error occurs. */
@@ -52,10 +50,7 @@ export const AuthProvider: ParentComponent<AuthProviderProps> = (props) => {
   let client: OidcClient | null = null;
 
   onMount(() => {
-    const oidcClient = new OidcClient({
-      ...props.config,
-      fetchProfile: props.fetchProfile ?? true,
-    });
+    const oidcClient = new OidcClient(props.config);
     client = oidcClient;
 
     const unsub = oidcClient.subscribe((newState) => {

--- a/packages/solid/src/context.tsx
+++ b/packages/solid/src/context.tsx
@@ -6,8 +6,7 @@ import {
   onCleanup,
   type ParentComponent,
 } from "solid-js";
-import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
-import type { OidcConfig } from "oidc-js-core";
+import { OidcClient, type OidcClientConfig, type AuthState, type LoginOptions } from "oidc-js";
 import type { AuthContextValue } from "./types.js";
 
 const AuthContext = createContext<AuthContextValue>();
@@ -17,7 +16,7 @@ const AuthContext = createContext<AuthContextValue>();
  */
 interface AuthProviderProps {
   /** OIDC configuration including issuer, clientId, and redirectUri. */
-  config: OidcConfig;
+  config: OidcClientConfig;
   /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
   fetchProfile?: boolean;
   /** Callback invoked after a successful login with the returnTo path. */

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -10,4 +10,5 @@ export type {
   LoginOptions,
 } from "./types.js";
 
+export type { OidcClientConfig } from "oidc-js";
 export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/solid/src/tests/context.test.tsx
+++ b/packages/solid/src/tests/context.test.tsx
@@ -166,7 +166,7 @@ describe("AuthProvider", () => {
     let authRef: ReturnType<typeof useAuth> | null = null;
 
     render(() => (
-      <AuthProvider config={CONFIG} fetchProfile={true}>
+      <AuthProvider config={{ ...CONFIG, fetchProfile: true }}>
         {(() => {
           authRef = useAuth();
           return <div>{authRef.isAuthenticated ? "authed" : "not-authed"}</div>;

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -1,8 +1,6 @@
-import type { OidcConfig } from "oidc-js-core";
-
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
-import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcClientConfig, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 import type { OidcUser } from "oidc-js-core";
 
 /**
@@ -28,7 +26,7 @@ export interface AuthActions {
  */
 export interface AuthContextValue {
   /** The OIDC configuration used to initialize the provider. */
-  config: OidcConfig;
+  config: OidcClientConfig;
   /** The authenticated user, or null if not logged in. */
   user: AuthUser | null;
   /** Whether the user is currently authenticated. */

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-svelte",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Simple OIDC authentication for Svelte 5. Context, runes, and auth guards with zero dependencies.",
   "type": "module",
   "svelte": "./dist/index.js",

--- a/packages/svelte/src/AuthProvider.svelte
+++ b/packages/svelte/src/AuthProvider.svelte
@@ -16,14 +16,14 @@
   ```
 -->
 <script lang="ts">
-  import type { OidcConfig } from "oidc-js-core";
+  import type { OidcClientConfig } from "oidc-js";
   import type { Snippet } from "svelte";
   import { onDestroy } from "svelte";
   import { AuthStateManager, setAuthContext } from "./context.svelte.js";
 
   interface Props {
     /** OIDC configuration including issuer, clientId, and redirectUri. */
-    config: OidcConfig;
+    config: OidcClientConfig;
     /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
     fetchProfile?: boolean;
     /** Callback invoked after a successful login with the returnTo path. */

--- a/packages/svelte/src/AuthProvider.svelte
+++ b/packages/svelte/src/AuthProvider.svelte
@@ -24,8 +24,6 @@
   interface Props {
     /** OIDC configuration including issuer, clientId, and redirectUri. */
     config: OidcClientConfig;
-    /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
-    fetchProfile?: boolean;
     /** Callback invoked after a successful login with the returnTo path. */
     onLogin?: (returnTo: string) => void;
     /** Callback invoked when an authentication error occurs. */
@@ -34,9 +32,9 @@
     children: Snippet;
   }
 
-  let { config, fetchProfile = true, onLogin, onError, children }: Props = $props();
+  let { config, onLogin, onError, children }: Props = $props();
 
-  const manager = new AuthStateManager(config, fetchProfile);
+  const manager = new AuthStateManager(config);
   setAuthContext(manager);
 
   const unsub = manager.client.subscribe((state) => {

--- a/packages/svelte/src/context.svelte.ts
+++ b/packages/svelte/src/context.svelte.ts
@@ -26,9 +26,9 @@ export class AuthStateManager {
   readonly client: OidcClient;
   readonly actions: AuthActions;
 
-  constructor(config: OidcClientConfig, fetchProfile: boolean) {
+  constructor(config: OidcClientConfig) {
     this.config = config;
-    this.client = new OidcClient({ ...config, fetchProfile });
+    this.client = new OidcClient(config);
 
     this.actions = {
       login: (options?: LoginOptions) => {

--- a/packages/svelte/src/context.svelte.ts
+++ b/packages/svelte/src/context.svelte.ts
@@ -1,6 +1,5 @@
 import { getContext, setContext } from "svelte";
-import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
-import type { OidcConfig } from "oidc-js-core";
+import { OidcClient, type OidcClientConfig, type AuthState, type LoginOptions } from "oidc-js";
 import type { AuthContextValue, AuthActions } from "./types.js";
 
 const AUTH_CONTEXT_KEY = Symbol("oidc-js-auth");
@@ -23,11 +22,11 @@ export class AuthStateManager {
     expiresAt: null,
   });
 
-  readonly config: OidcConfig;
+  readonly config: OidcClientConfig;
   readonly client: OidcClient;
   readonly actions: AuthActions;
 
-  constructor(config: OidcConfig, fetchProfile: boolean) {
+  constructor(config: OidcClientConfig, fetchProfile: boolean) {
     this.config = config;
     this.client = new OidcClient({ ...config, fetchProfile });
 

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -11,4 +11,5 @@ export type {
   LoginOptions,
 } from "./types.js";
 
+export type { OidcClientConfig } from "oidc-js";
 export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/svelte/src/tests/context.test.ts
+++ b/packages/svelte/src/tests/context.test.ts
@@ -58,20 +58,20 @@ afterEach(() => {
 describe("AuthStateManager", () => {
   it("creates OidcClient with config", async () => {
     const { OidcClient } = await vi.importMock<typeof import("oidc-js")>("oidc-js");
-    new AuthStateManager(CONFIG, true);
+    new AuthStateManager(CONFIG);
 
-    expect(OidcClient).toHaveBeenCalledWith({ ...CONFIG, fetchProfile: true });
+    expect(OidcClient).toHaveBeenCalledWith(CONFIG);
   });
 
   it("exposes config and client", () => {
-    const manager = new AuthStateManager(CONFIG, false);
+    const manager = new AuthStateManager({ ...CONFIG, fetchProfile: false });
 
-    expect(manager.config).toEqual(CONFIG);
+    expect(manager.config).toEqual({ ...CONFIG, fetchProfile: false });
     expect(manager.client).toBeDefined();
   });
 
   it("has correct initial state", () => {
-    const manager = new AuthStateManager(CONFIG, true);
+    const manager = new AuthStateManager(CONFIG);
 
     expect(manager.user).toBeNull();
     expect(manager.isAuthenticated).toBe(false);
@@ -81,7 +81,7 @@ describe("AuthStateManager", () => {
   });
 
   it("updates state via update()", () => {
-    const manager = new AuthStateManager(CONFIG, true);
+    const manager = new AuthStateManager(CONFIG);
 
     manager.update({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -99,7 +99,7 @@ describe("AuthStateManager", () => {
   });
 
   it("exposes actions that delegate to client", () => {
-    const manager = new AuthStateManager(CONFIG, true);
+    const manager = new AuthStateManager(CONFIG);
 
     manager.actions.login();
     expect(mockClientInstance.login).toHaveBeenCalled();
@@ -125,7 +125,7 @@ describe("getAuthContext", () => {
 
 describe("setAuthContext / getAuthContext round-trip", () => {
   it("setAuthContext stores context retrievable by getAuthContext", () => {
-    const manager = new AuthStateManager(CONFIG, true);
+    const manager = new AuthStateManager(CONFIG);
 
     setAuthContext(manager);
     const ctx = getAuthContext();

--- a/packages/svelte/src/types.ts
+++ b/packages/svelte/src/types.ts
@@ -1,8 +1,6 @@
-import type { OidcConfig } from "oidc-js-core";
-
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
-import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcClientConfig, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 import type { OidcUser } from "oidc-js-core";
 
 /** Actions available to interact with the OIDC authentication flow. */
@@ -20,7 +18,7 @@ export interface AuthActions {
 /** Reactive authentication context value provided by {@link AuthProvider}. */
 export interface AuthContextValue {
   /** The OIDC configuration used by the provider. */
-  readonly config: OidcConfig;
+  readonly config: OidcClientConfig;
   /** The authenticated user, or null if not logged in. */
   readonly user: AuthUser | null;
   /** Whether the user is currently authenticated. */

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-js-vue",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Simple OIDC authentication for Vue. Plugin, composables, and navigation guards with zero dependencies.",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -16,4 +16,5 @@ export type {
   OidcPluginOptions,
 } from "./types.js";
 
+export type { OidcClientConfig } from "oidc-js";
 export type { OidcConfig, OidcUser, TokenSet } from "oidc-js-core";

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -1,6 +1,5 @@
 import { ref, type App, type InjectionKey, type Ref } from "vue";
-import { OidcClient, type AuthState, type LoginOptions } from "oidc-js";
-import type { OidcConfig } from "oidc-js-core";
+import { OidcClient, type OidcClientConfig, type AuthState, type LoginOptions } from "oidc-js";
 import type { AuthActions, AuthContextValue, OidcPluginOptions } from "./types.js";
 
 /**
@@ -10,7 +9,7 @@ import type { AuthActions, AuthContextValue, OidcPluginOptions } from "./types.j
  * to provide and inject the reactive auth state.
  */
 export const AUTH_CONTEXT_KEY: InjectionKey<{
-  config: OidcConfig;
+  config: OidcClientConfig;
   user: Ref<AuthContextValue["user"]>;
   isAuthenticated: Ref<boolean>;
   isLoading: Ref<boolean>;

--- a/packages/vue/src/plugin.ts
+++ b/packages/vue/src/plugin.ts
@@ -47,9 +47,9 @@ export const AUTH_CONTEXT_KEY: InjectionKey<{
  */
 export const oidcPlugin = {
   install(app: App, options: OidcPluginOptions): void {
-    const { config, fetchProfile = true, onLogin, onError } = options;
+    const { config, onLogin, onError } = options;
 
-    const client = new OidcClient({ ...config, fetchProfile });
+    const client = new OidcClient(config);
 
     const user = ref<AuthContextValue["user"]>(null);
     const isAuthenticated = ref(false);

--- a/packages/vue/src/tests/plugin.test.ts
+++ b/packages/vue/src/tests/plugin.test.ts
@@ -102,7 +102,7 @@ describe("oidcPlugin", () => {
   it("creates OidcClient with config and fetchProfile", async () => {
     const { OidcClient } = await vi.importMock<typeof import("oidc-js")>("oidc-js");
 
-    const { app, root } = mountAppWithPlugin({ fetchProfile: false });
+    const { app, root } = mountAppWithPlugin({ config: { ...CONFIG, fetchProfile: false } });
 
     expect(OidcClient).toHaveBeenCalledWith({ ...CONFIG, fetchProfile: false });
 

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,8 +1,6 @@
-import type { OidcConfig } from "oidc-js-core";
-
 export type { IdTokenClaims, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 
-import type { AuthUser, AuthTokens, LoginOptions } from "oidc-js";
+import type { OidcClientConfig, AuthUser, AuthTokens, LoginOptions } from "oidc-js";
 import type { OidcUser } from "oidc-js-core";
 
 /**
@@ -29,7 +27,7 @@ export interface AuthActions {
  */
 export interface AuthContextValue {
   /** The OIDC configuration used to initialize the client. */
-  config: OidcConfig;
+  config: OidcClientConfig;
   /** The authenticated user, or null if not logged in. */
   user: AuthUser | null;
   /** Whether the user is currently authenticated. */
@@ -52,7 +50,7 @@ export interface AuthContextValue {
  */
 export interface OidcPluginOptions {
   /** OIDC configuration including issuer, clientId, and redirectUri. */
-  config: OidcConfig;
+  config: OidcClientConfig;
   /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
   fetchProfile?: boolean;
   /** Callback invoked after a successful login with the returnTo path. */

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -51,8 +51,6 @@ export interface AuthContextValue {
 export interface OidcPluginOptions {
   /** OIDC configuration including issuer, clientId, and redirectUri. */
   config: OidcClientConfig;
-  /** Whether to fetch the userinfo profile after token exchange. Defaults to true. */
-  fetchProfile?: boolean;
   /** Callback invoked after a successful login with the returnTo path. */
   onLogin?: (returnTo: string) => void;
   /** Callback invoked when an authentication error occurs. */

--- a/tests/e2e/angular-app/src/main.ts
+++ b/tests/e2e/angular-app/src/main.ts
@@ -7,6 +7,7 @@ import { AppComponent } from "./app/app.component";
 import { routes } from "./app/app.routes";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const viteEnv = (import.meta as any).env ?? {};
 const idpPort = viteEnv.VITE_IDP_PORT ?? "9999";
@@ -18,6 +19,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
 };
 
 bootstrapApplication(AppComponent, {

--- a/tests/e2e/angular-app/src/main.ts
+++ b/tests/e2e/angular-app/src/main.ts
@@ -20,7 +20,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
+  autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
 bootstrapApplication(AppComponent, {

--- a/tests/e2e/angular-app/src/main.ts
+++ b/tests/e2e/angular-app/src/main.ts
@@ -8,6 +8,7 @@ import { routes } from "./app/app.routes";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
 const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const viteEnv = (import.meta as any).env ?? {};
 const idpPort = viteEnv.VITE_IDP_PORT ?? "9999";

--- a/tests/e2e/angular-app/src/main.ts
+++ b/tests/e2e/angular-app/src/main.ts
@@ -24,8 +24,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideRouter(routes),
     provideAuth({
-      config,
-      fetchProfile,
+      config: { ...config, fetchProfile },
     }),
   ],
 }).catch((err) => console.error(err));

--- a/tests/e2e/angular-app/src/main.ts
+++ b/tests/e2e/angular-app/src/main.ts
@@ -7,7 +7,7 @@ import { AppComponent } from "./app/app.component";
 import { routes } from "./app/app.routes";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
-const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+const autoRefreshInterval = Number(localStorage.getItem("e2e-autoRefreshInterval"));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const viteEnv = (import.meta as any).env ?? {};
@@ -20,7 +20,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
+  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
 };
 
 bootstrapApplication(AppComponent, {

--- a/tests/e2e/angular-app/src/main.ts
+++ b/tests/e2e/angular-app/src/main.ts
@@ -20,6 +20,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  fetchProfile,
   autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
@@ -27,7 +28,7 @@ bootstrapApplication(AppComponent, {
   providers: [
     provideRouter(routes),
     provideAuth({
-      config: { ...config, fetchProfile },
+      config,
     }),
   ],
 }).catch((err) => console.error(err));

--- a/tests/e2e/kasper-app/src/components/App.kasper
+++ b/tests/e2e/kasper-app/src/components/App.kasper
@@ -20,6 +20,7 @@ export class AppRoot extends Component {
   fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
 
   config = (() => {
+    const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
     const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
     const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
     return {
@@ -28,6 +29,7 @@ export class AppRoot extends Component {
       redirectUri: `http://localhost:${appPort}/callback`,
       scopes: ["openid", "profile", "email", "offline_access"],
       postLogoutRedirectUri: `http://localhost:${appPort}`,
+      ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
     };
   })();
 

--- a/tests/e2e/kasper-app/src/components/App.kasper
+++ b/tests/e2e/kasper-app/src/components/App.kasper
@@ -29,7 +29,7 @@ export class AppRoot extends Component {
       redirectUri: `http://localhost:${appPort}/callback`,
       scopes: ["openid", "profile", "email", "offline_access"],
       postLogoutRedirectUri: `http://localhost:${appPort}`,
-      ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
+      autoRefreshInterval: autoRefreshInterval || undefined,
     };
   })();
 

--- a/tests/e2e/kasper-app/src/components/App.kasper
+++ b/tests/e2e/kasper-app/src/components/App.kasper
@@ -1,5 +1,5 @@
 <template>
-  <auth-provider @:config="config" @:fetchProfile="fetchProfile" @:onLogin="handleLogin">
+  <auth-provider @:config="config" @:onLogin="handleLogin">
     <router>
       <route @path="/" @component="HomePage" />
       <route @path="/callback" @component="CallbackPage" />
@@ -17,10 +17,10 @@ import { ProtectedAPage } from "./ProtectedA.kasper";
 import { ProtectedBPage } from "./ProtectedB.kasper";
 
 export class AppRoot extends Component {
-  fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
-
   config = (() => {
+    const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
     const autoRefreshInterval = Number(localStorage.getItem("e2e-autoRefreshInterval"));
+
     const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
     const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
     return {
@@ -29,6 +29,7 @@ export class AppRoot extends Component {
       redirectUri: `http://localhost:${appPort}/callback`,
       scopes: ["openid", "profile", "email", "offline_access"],
       postLogoutRedirectUri: `http://localhost:${appPort}`,
+      fetchProfile,
       autoRefreshInterval: autoRefreshInterval || undefined,
     };
   })();

--- a/tests/e2e/kasper-app/src/components/App.kasper
+++ b/tests/e2e/kasper-app/src/components/App.kasper
@@ -20,7 +20,7 @@ export class AppRoot extends Component {
   fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
 
   config = (() => {
-    const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+    const autoRefreshInterval = Number(localStorage.getItem("e2e-autoRefreshInterval"));
     const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
     const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
     return {
@@ -29,7 +29,7 @@ export class AppRoot extends Component {
       redirectUri: `http://localhost:${appPort}/callback`,
       scopes: ["openid", "profile", "email", "offline_access"],
       postLogoutRedirectUri: `http://localhost:${appPort}`,
-      ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
+      ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
     };
   })();
 

--- a/tests/e2e/lit-app/src/app-root.ts
+++ b/tests/e2e/lit-app/src/app-root.ts
@@ -18,13 +18,14 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  fetchProfile,
   autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
 @customElement("app-root")
 export class AppRoot extends LitElement {
   auth = new AuthController(this, {
-    config: { ...config, fetchProfile },
+    config,
     onLogin: (returnTo: string) => {
       window.history.replaceState({}, "", returnTo);
       this._path = window.location.pathname;

--- a/tests/e2e/lit-app/src/app-root.ts
+++ b/tests/e2e/lit-app/src/app-root.ts
@@ -8,6 +8,7 @@ import "./pages/protected-b-page.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
 const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 

--- a/tests/e2e/lit-app/src/app-root.ts
+++ b/tests/e2e/lit-app/src/app-root.ts
@@ -7,6 +7,7 @@ import "./pages/protected-a-page.js";
 import "./pages/protected-b-page.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
@@ -16,6 +17,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
 };
 
 @customElement("app-root")

--- a/tests/e2e/lit-app/src/app-root.ts
+++ b/tests/e2e/lit-app/src/app-root.ts
@@ -21,8 +21,7 @@ const config = {
 @customElement("app-root")
 export class AppRoot extends LitElement {
   auth = new AuthController(this, {
-    config,
-    fetchProfile,
+    config: { ...config, fetchProfile },
     onLogin: (returnTo: string) => {
       window.history.replaceState({}, "", returnTo);
       this._path = window.location.pathname;

--- a/tests/e2e/lit-app/src/app-root.ts
+++ b/tests/e2e/lit-app/src/app-root.ts
@@ -18,7 +18,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
+  autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
 @customElement("app-root")

--- a/tests/e2e/lit-app/src/app-root.ts
+++ b/tests/e2e/lit-app/src/app-root.ts
@@ -7,7 +7,7 @@ import "./pages/protected-a-page.js";
 import "./pages/protected-b-page.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
-const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+const autoRefreshInterval = Number(localStorage.getItem("e2e-autoRefreshInterval"));
 
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
@@ -18,7 +18,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
+  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
 };
 
 @customElement("app-root")

--- a/tests/e2e/preact-app/src/index.tsx
+++ b/tests/e2e/preact-app/src/index.tsx
@@ -16,7 +16,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
+  autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
 function Root() {

--- a/tests/e2e/preact-app/src/index.tsx
+++ b/tests/e2e/preact-app/src/index.tsx
@@ -5,6 +5,7 @@ import { useCallback } from "preact/hooks";
 import { App } from "./App.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
@@ -14,6 +15,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
 };
 
 function Root() {

--- a/tests/e2e/preact-app/src/index.tsx
+++ b/tests/e2e/preact-app/src/index.tsx
@@ -6,6 +6,7 @@ import { App } from "./App.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
 const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 

--- a/tests/e2e/preact-app/src/index.tsx
+++ b/tests/e2e/preact-app/src/index.tsx
@@ -16,6 +16,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  fetchProfile,
   autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
@@ -25,7 +26,7 @@ function Root() {
   }, []);
 
   return (
-    <AuthProvider config={{ ...config, fetchProfile }} onLogin={onLogin}>
+    <AuthProvider config={config} onLogin={onLogin}>
       <App />
     </AuthProvider>
   );

--- a/tests/e2e/preact-app/src/index.tsx
+++ b/tests/e2e/preact-app/src/index.tsx
@@ -22,7 +22,7 @@ function Root() {
   }, []);
 
   return (
-    <AuthProvider config={config} fetchProfile={fetchProfile} onLogin={onLogin}>
+    <AuthProvider config={{ ...config, fetchProfile }} onLogin={onLogin}>
       <App />
     </AuthProvider>
   );

--- a/tests/e2e/preact-app/src/index.tsx
+++ b/tests/e2e/preact-app/src/index.tsx
@@ -5,7 +5,7 @@ import { useCallback } from "preact/hooks";
 import { App } from "./App.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
-const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+const autoRefreshInterval = Number(localStorage.getItem("e2e-autoRefreshInterval"));
 
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
@@ -16,7 +16,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
+  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
 };
 
 function Root() {

--- a/tests/e2e/react-app/src/main.tsx
+++ b/tests/e2e/react-app/src/main.tsx
@@ -16,7 +16,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
+  autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
 function Root() {

--- a/tests/e2e/react-app/src/main.tsx
+++ b/tests/e2e/react-app/src/main.tsx
@@ -6,6 +6,7 @@ import { App } from "./App.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
 const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 

--- a/tests/e2e/react-app/src/main.tsx
+++ b/tests/e2e/react-app/src/main.tsx
@@ -16,6 +16,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  fetchProfile,
   autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
@@ -26,7 +27,7 @@ function Root() {
   }, [navigate]);
 
   return (
-    <AuthProvider config={{ ...config, fetchProfile }} onLogin={onLogin}>
+    <AuthProvider config={config} onLogin={onLogin}>
       <App />
     </AuthProvider>
   );

--- a/tests/e2e/react-app/src/main.tsx
+++ b/tests/e2e/react-app/src/main.tsx
@@ -5,6 +5,7 @@ import { useCallback } from "react";
 import { App } from "./App.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
@@ -14,6 +15,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
 };
 
 function Root() {

--- a/tests/e2e/react-app/src/main.tsx
+++ b/tests/e2e/react-app/src/main.tsx
@@ -5,7 +5,7 @@ import { useCallback } from "react";
 import { App } from "./App.js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
-const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+const autoRefreshInterval = Number(localStorage.getItem("e2e-autoRefreshInterval"));
 
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
@@ -16,7 +16,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
+  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
 };
 
 function Root() {

--- a/tests/e2e/react-app/src/main.tsx
+++ b/tests/e2e/react-app/src/main.tsx
@@ -23,7 +23,7 @@ function Root() {
   }, [navigate]);
 
   return (
-    <AuthProvider config={config} fetchProfile={fetchProfile} onLogin={onLogin}>
+    <AuthProvider config={{ ...config, fetchProfile }} onLogin={onLogin}>
       <App />
     </AuthProvider>
   );

--- a/tests/e2e/solid-app/src/App.tsx
+++ b/tests/e2e/solid-app/src/App.tsx
@@ -14,6 +14,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  fetchProfile,
   autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
@@ -24,7 +25,7 @@ export const App: ParentComponent = (props) => {
   };
 
   return (
-    <AuthProvider config={{ ...config, fetchProfile }} onLogin={onLogin}>
+    <AuthProvider config={config} onLogin={onLogin}>
       {props.children}
     </AuthProvider>
   );

--- a/tests/e2e/solid-app/src/App.tsx
+++ b/tests/e2e/solid-app/src/App.tsx
@@ -4,6 +4,7 @@ import type { ParentComponent } from "solid-js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
 const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 

--- a/tests/e2e/solid-app/src/App.tsx
+++ b/tests/e2e/solid-app/src/App.tsx
@@ -21,7 +21,7 @@ export const App: ParentComponent = (props) => {
   };
 
   return (
-    <AuthProvider config={config} fetchProfile={fetchProfile} onLogin={onLogin}>
+    <AuthProvider config={{ ...config, fetchProfile }} onLogin={onLogin}>
       {props.children}
     </AuthProvider>
   );

--- a/tests/e2e/solid-app/src/App.tsx
+++ b/tests/e2e/solid-app/src/App.tsx
@@ -14,7 +14,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
+  autoRefreshInterval: autoRefreshInterval || undefined,
 };
 
 export const App: ParentComponent = (props) => {

--- a/tests/e2e/solid-app/src/App.tsx
+++ b/tests/e2e/solid-app/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthProvider } from "oidc-js-solid";
 import type { ParentComponent } from "solid-js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
@@ -12,6 +13,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
+  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
 };
 
 export const App: ParentComponent = (props) => {

--- a/tests/e2e/solid-app/src/App.tsx
+++ b/tests/e2e/solid-app/src/App.tsx
@@ -3,7 +3,7 @@ import { AuthProvider } from "oidc-js-solid";
 import type { ParentComponent } from "solid-js";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
-const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+const autoRefreshInterval = Number(localStorage.getItem("e2e-autoRefreshInterval"));
 
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
@@ -14,7 +14,7 @@ const config = {
   redirectUri: `http://localhost:${appPort}/callback`,
   scopes: ["openid", "profile", "email", "offline_access"],
   postLogoutRedirectUri: `http://localhost:${appPort}`,
-  ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
+  ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
 };
 
 export const App: ParentComponent = (props) => {

--- a/tests/e2e/specs/oidc.spec.ts
+++ b/tests/e2e/specs/oidc.spec.ts
@@ -576,6 +576,39 @@ test.describe(`[${FRAMEWORK}] RequireAuth`, () => {
   });
 });
 
+test.describe(`[${FRAMEWORK}] Proactive Auto-Refresh`, () => {
+  // Configures autoRefreshInterval=1s via localStorage, logs in, simulates token expiry,
+  // and verifies that the polling interval automatically triggers a token refresh
+  // without any user interaction (no navigation, no button click).
+  test("auto-refresh polling refreshes expired token without user interaction", async ({ page }) => {
+    const traffic = trackTraffic(page);
+    // Set 1-second polling interval before the app loads with it
+    await page.goto("/", { waitUntil: "networkidle" });
+    await page.evaluate(() => localStorage.setItem("e2e-autoRefreshInterval", "1"));
+
+    // login() calls page.goto("/") which reloads with the new interval
+    await login(page);
+    const oldToken = await page.getByTestId("access-token-value").textContent();
+    const expiresAt = Number(await page.getByTestId("expires-at").textContent());
+
+    // Snapshot request count after login, before auto-refresh fires
+    const requestCountAfterLogin = traffic.requests().length;
+
+    // Advance Date.now past token expiry — the 1s interval will detect it and auto-refresh
+    await simulateTokenExpiry(page, expiresAt);
+
+    // Token should change without any user interaction (no click, no navigation)
+    await expect(page.getByTestId("access-token-value")).not.toHaveText(oldToken!, { timeout: TIMEOUT });
+    await expect(page.getByTestId("authenticated")).toBeVisible();
+
+    // Verify that auto-refresh issued a POST /token after login completed
+    const autoRefreshRequests = traffic.requests().slice(requestCountAfterLogin);
+    expect(autoRefreshRequests).toContain(POST_TOKEN);
+
+    await page.evaluate(() => localStorage.removeItem("e2e-autoRefreshInterval"));
+  });
+});
+
 test.describe(`[${FRAMEWORK}] Nonce Validation`, () => {
   // Tampers with the stored nonce before callback. The library should detect the mismatch
   // and surface an error instead of accepting the tokens (prevents token injection/replay).

--- a/tests/e2e/svelte-app/src/App.svelte
+++ b/tests/e2e/svelte-app/src/App.svelte
@@ -6,7 +6,7 @@
   import ProtectedB from "./routes/ProtectedB.svelte";
 
   const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
-  const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+  const autoRefreshInterval = Number(localStorage.getItem("e2e-autoRefreshInterval"));
 
   const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
   const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
@@ -17,7 +17,7 @@
     redirectUri: `http://localhost:${appPort}/callback`,
     scopes: ["openid", "profile", "email", "offline_access"],
     postLogoutRedirectUri: `http://localhost:${appPort}`,
-    ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
+    ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
   };
 
   let path = $state(window.location.pathname);

--- a/tests/e2e/svelte-app/src/App.svelte
+++ b/tests/e2e/svelte-app/src/App.svelte
@@ -17,7 +17,7 @@
     redirectUri: `http://localhost:${appPort}/callback`,
     scopes: ["openid", "profile", "email", "offline_access"],
     postLogoutRedirectUri: `http://localhost:${appPort}`,
-    ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
+    autoRefreshInterval: autoRefreshInterval || undefined,
   };
 
   let path = $state(window.location.pathname);

--- a/tests/e2e/svelte-app/src/App.svelte
+++ b/tests/e2e/svelte-app/src/App.svelte
@@ -7,6 +7,7 @@
 
   const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
   const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+
   const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
   const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 

--- a/tests/e2e/svelte-app/src/App.svelte
+++ b/tests/e2e/svelte-app/src/App.svelte
@@ -38,7 +38,7 @@
   });
 </script>
 
-<AuthProvider {config} {fetchProfile} onLogin={handleLogin}>
+<AuthProvider config={{ ...config, fetchProfile }} onLogin={handleLogin}>
   {#snippet children()}
     {#if path === "/callback"}
       <Callback />

--- a/tests/e2e/svelte-app/src/App.svelte
+++ b/tests/e2e/svelte-app/src/App.svelte
@@ -17,6 +17,7 @@
     redirectUri: `http://localhost:${appPort}/callback`,
     scopes: ["openid", "profile", "email", "offline_access"],
     postLogoutRedirectUri: `http://localhost:${appPort}`,
+    fetchProfile,
     autoRefreshInterval: autoRefreshInterval || undefined,
   };
 
@@ -41,7 +42,7 @@
   });
 </script>
 
-<AuthProvider config={{ ...config, fetchProfile }} onLogin={handleLogin}>
+<AuthProvider config={config} onLogin={handleLogin}>
   {#snippet children()}
     {#if path === "/callback"}
       <Callback />

--- a/tests/e2e/svelte-app/src/App.svelte
+++ b/tests/e2e/svelte-app/src/App.svelte
@@ -6,6 +6,7 @@
   import ProtectedB from "./routes/ProtectedB.svelte";
 
   const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+  const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
   const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
   const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
@@ -15,6 +16,7 @@
     redirectUri: `http://localhost:${appPort}/callback`,
     scopes: ["openid", "profile", "email", "offline_access"],
     postLogoutRedirectUri: `http://localhost:${appPort}`,
+    ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
   };
 
   let path = $state(window.location.pathname);

--- a/tests/e2e/vue-app/src/main.ts
+++ b/tests/e2e/vue-app/src/main.ts
@@ -8,7 +8,7 @@ import ProtectedA from "./views/ProtectedA.vue";
 import ProtectedB from "./views/ProtectedB.vue";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
-const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+const autoRefreshInterval = Number(localStorage.getItem("e2e-autoRefreshInterval"));
 
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
@@ -33,7 +33,7 @@ app.use(oidcPlugin, {
     scopes: ["openid", "profile", "email", "offline_access"],
     postLogoutRedirectUri: `http://localhost:${appPort}`,
     fetchProfile,
-    ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
+    ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
   },
   onLogin(returnTo: string) {
     router.replace(returnTo);

--- a/tests/e2e/vue-app/src/main.ts
+++ b/tests/e2e/vue-app/src/main.ts
@@ -33,7 +33,7 @@ app.use(oidcPlugin, {
     scopes: ["openid", "profile", "email", "offline_access"],
     postLogoutRedirectUri: `http://localhost:${appPort}`,
     fetchProfile,
-    ...(autoRefreshInterval ? { autoRefreshInterval } : {}),
+    autoRefreshInterval: autoRefreshInterval || undefined,
   },
   onLogin(returnTo: string) {
     router.replace(returnTo);

--- a/tests/e2e/vue-app/src/main.ts
+++ b/tests/e2e/vue-app/src/main.ts
@@ -8,6 +8,7 @@ import ProtectedA from "./views/ProtectedA.vue";
 import ProtectedB from "./views/ProtectedB.vue";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
+const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 
@@ -31,6 +32,7 @@ app.use(oidcPlugin, {
     scopes: ["openid", "profile", "email", "offline_access"],
     postLogoutRedirectUri: `http://localhost:${appPort}`,
     fetchProfile,
+    ...(autoRefreshInterval ? { autoRefreshInterval: Number(autoRefreshInterval) } : {}),
   },
   onLogin(returnTo: string) {
     router.replace(returnTo);

--- a/tests/e2e/vue-app/src/main.ts
+++ b/tests/e2e/vue-app/src/main.ts
@@ -9,6 +9,7 @@ import ProtectedB from "./views/ProtectedB.vue";
 
 const fetchProfile = localStorage.getItem("e2e-fetchProfile") !== "false";
 const autoRefreshInterval = localStorage.getItem("e2e-autoRefreshInterval");
+
 const idpPort = import.meta.env.VITE_IDP_PORT ?? "9999";
 const appPort = import.meta.env.VITE_APP_PORT ?? "5173";
 

--- a/tests/e2e/vue-app/src/main.ts
+++ b/tests/e2e/vue-app/src/main.ts
@@ -30,8 +30,8 @@ app.use(oidcPlugin, {
     redirectUri: `http://localhost:${appPort}/callback`,
     scopes: ["openid", "profile", "email", "offline_access"],
     postLogoutRedirectUri: `http://localhost:${appPort}`,
+    fetchProfile,
   },
-  fetchProfile,
   onLogin(returnTo: string) {
     router.replace(returnTo);
   },


### PR DESCRIPTION
## Summary
- Adds `setInterval`-based proactive token refresh to `OidcClient` that renews the access token before it expires
- Two new config options: `autoRefresh` (default `true`) and `autoRefreshInterval` in seconds (default `10`)
- On failure, polling stops to avoid hammering the token endpoint; a successful manual refresh or new login restarts it
- Updated token-refresh guide with proactive refresh documentation

## Test plan
- [x] Auto-refresh triggers when token is near expiry
- [x] No refresh when token is not near expiry
- [x] Disabled with `autoRefresh: false`
- [x] Stops on logout
- [x] Stops on destroy
- [x] Stops polling after a failed refresh (no endpoint hammering)
- [x] Restarts after failed auto-refresh followed by successful manual refresh

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)